### PR TITLE
Replace bs4 with beautifulsoup4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ packages = [
 [tool.poetry.dependencies]
 python = "^3.10"
 aiohttp = "*"
-bs4 = "*"
+beautifulsoup4 = "*"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.0"


### PR DESCRIPTION
Distributions usually don't ship the `bs4` dummy package.