### PR TITLE
feat: support Technicolor Vodafone Stations from Germany

### DIFF
--- a/library_test.py
+++ b/library_test.py
@@ -2,7 +2,11 @@ import argparse
 import asyncio
 import logging
 
-from aiovodafone.api import VodafoneStationSercommApi
+from aiovodafone.api import (
+    VodafoneStationCommonApi,
+    VodafoneStationSercommApi,
+    VodafoneStationTechnicolorApi,
+)
 from aiovodafone.exceptions import AlreadyLogged, CannotConnect, ModelNotSupported
 
 
@@ -16,6 +20,14 @@ def get_arguments() -> tuple[argparse.ArgumentParser, argparse.Namespace]:
         "--username", "-u", type=str, default="vodafone", help="Set router username"
     )
     parser.add_argument("--password", "-p", type=str, help="Set router password")
+
+    parser.add_argument(
+        "--device-type",
+        "-d",
+        type=str,
+        default="Sercomm",
+        help="Set device type, either Sercomm or Technicolor",
+    )
 
     arguments = parser.parse_args()
 
@@ -31,7 +43,12 @@ async def main() -> None:
         exit(1)
 
     print("-" * 20)
-    api = VodafoneStationSercommApi(args.router, args.username, args.password)
+    api: VodafoneStationCommonApi
+    if args.device_type == "Technicolor":
+        api = VodafoneStationTechnicolorApi(args.router, args.username, args.password)
+    else:
+        api = VodafoneStationSercommApi(args.router, args.username, args.password)
+
     logged = False
     exc = False
     try:


### PR DESCRIPTION
Replaces #39 

* add implementation for login, logout and get devices
* make VodafoneStationCommonApi abstract and move some functions up and down 
* extract hash calculation, pull up convert_uptime
* make library_test support the different classes
* add param `raw` to `_get_page_result`, as not all can be parsed as json
* add param `use_html_content_type`, as German stations deliver nicely as json, so typing needs to be skipped
* only the `X-Requested-With` header is needed. If that is missing, the host request fails