### PR TITLE
feat: support Technicolor Vodafone Stations

### DIFF
--- a/library_test.py
+++ b/library_test.py
@@ -2,7 +2,11 @@ import argparse
 import asyncio
 import logging
 
-from aiovodafone.api import VodafoneStationSercommApi
+from aiovodafone.api import (
+    VodafoneStationCommonApi,
+    VodafoneStationSercommApi,
+    VodafoneStationTechnicolorApi,
+)
 from aiovodafone.exceptions import AlreadyLogged, CannotConnect, ModelNotSupported
 
 
@@ -16,6 +20,14 @@ def get_arguments() -> tuple[argparse.ArgumentParser, argparse.Namespace]:
         "--username", "-u", type=str, default="vodafone", help="Set router username"
     )
     parser.add_argument("--password", "-p", type=str, help="Set router password")
+
+    parser.add_argument(
+        "--device-type",
+        "-d",
+        type=str,
+        default="Sercomm",
+        help="Set device type, either Sercomm or Technicolor",
+    )
 
     arguments = parser.parse_args()
 
@@ -31,7 +43,12 @@ async def main() -> None:
         exit(1)
 
     print("-" * 20)
-    api = VodafoneStationSercommApi(args.router, args.username, args.password)
+    api: VodafoneStationCommonApi
+    if args.device_type == "Technicolor":
+        api = VodafoneStationTechnicolorApi(args.router, args.username, args.password)
+    else:
+        api = VodafoneStationSercommApi(args.router, args.username, args.password)
+
     logged = False
     exc = False
     try:

--- a/src/aiovodafone/api.py
+++ b/src/aiovodafone/api.py
@@ -209,12 +209,12 @@ class VodafoneStationTechnicolorApi(VodafoneStationCommonApi):
             connected = bool(device["active"])
             connection_type = (
                 "WiFi" if "WiFi" in device["layer1interface"] else "Ethernet"
-            )  # TODO clarify if those are the right values
+            )
             ip_address = device["ipaddress"]
             name = device["hostname"]
             mac = device["physaddress"]
-            type = ""  # TODO clarify what type contains
-            wifi = ""  # TODO clarify what is meant
+            type = device["type"]
+            wifi = ""  # Technicolor Vodafone Station does not report wifi band
 
             vdf_device = VodafoneStationDevice(
                 connected=connected,

--- a/src/aiovodafone/api.py
+++ b/src/aiovodafone/api.py
@@ -99,6 +99,10 @@ class VodafoneStationCommonApi(ABC):
             allow_redirects=False,
         )
 
+    @abstractmethod
+    async def convert_uptime(self, uptime: str) -> datetime:
+        pass
+
     async def close(self) -> None:
         """Router close session."""
         await self.session.close()

--- a/src/aiovodafone/api.py
+++ b/src/aiovodafone/api.py
@@ -159,7 +159,9 @@ class VodafoneStationTechnicolorApi(VodafoneStationCommonApi):
         _LOGGER.debug("Logging into %s", self.host)
         _LOGGER.debug("Get salt for login")
         payload = {"username": self.username, "password": "seeksalthash"}
-        salt_response = await self._post_page_result(page="/api/v1/session/login", payload=payload)
+        salt_response = await self._post_page_result(
+            page="/api/v1/session/login", payload=payload
+        )
 
         salt_json = await salt_response.json()
 

--- a/src/aiovodafone/api.py
+++ b/src/aiovodafone/api.py
@@ -47,9 +47,8 @@ class VodafoneStationCommonApi(ABC):
         self.base_url = self._base_url()
         self.headers = {
             "User-Agent": "Mozilla/5.0 (X11; Fedora; Linux x86_64; rv:78.0) Gecko/20100101 Firefox/78.0",
-            "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
             "Accept-Language": "en-GB,en;q=0.5",
-            "DNT": "1",
+            "X-Requested-With": "XMLHttpRequest",
         }
         jar = aiohttp.CookieJar(unsafe=True)
         self.session = aiohttp.ClientSession(cookie_jar=jar)
@@ -126,10 +125,6 @@ class VodafoneStationCommonApi(ABC):
 
 class VodafoneStationTechnicolorApi(VodafoneStationCommonApi):
     """Queries Vodafone Station running Technicolor firmware."""
-
-    def __init__(self, host: str, username: str, password: str) -> None:
-        super().__init__(host, username, password)
-        self.headers["X-Requested-With"] = "XMLHttpRequest"
 
     async def _encrypt_string(
         self, credential: str, salt: str, salt_web_ui: str

--- a/src/aiovodafone/api.py
+++ b/src/aiovodafone/api.py
@@ -86,7 +86,6 @@ class VodafoneStationCommonApi(ABC):
         )
 
     async def _get_page_result(self, page: str) -> aiohttp.ClientResponse:
-
         """Get data from a web page via GET."""
         _LOGGER.debug("GET page  %s [%s]", page, self.host)
         timestamp = int(datetime.now().timestamp())
@@ -162,9 +161,7 @@ class VodafoneStationTechnicolorApi(VodafoneStationCommonApi):
         _LOGGER.debug("Get salt for login")
         page = "/api/v1/session/login"
         payload = {"username": self.username, "password": "seeksalthash"}
-        salt_response = await self._post_page_result(
-            page=page, payload=payload
-        )
+        salt_response = await self._post_page_result(page=page, payload=payload)
 
         salt = salt_response["salt"]
         salt_web_ui = salt_response["saltwebui"]

--- a/src/aiovodafone/const.py
+++ b/src/aiovodafone/const.py
@@ -11,3 +11,5 @@ LOGIN = [
     "credential error",
     "password mismatch",
 ]
+
+USER_ALREADY_LOGGED_IN = "MSG_LOGIN_150"


### PR DESCRIPTION
Replaces #39 and #43

* add implementation for login, logout and get devices
* make VodafoneStationCommonApi abstract and move some functions up and down 
* extract hash calculation, pull up convert_uptime
* make library_test support the different classes
* add param `raw` to `_get_page_result`, as not all can be parsed as json
* add param `use_html_content_type`, as German stations deliver nicely as json, so typing needs to be skipped
* only the `X-Requested-With` header is needed. If that is missing, the host request fails