### PR TITLE
fix: interpret connected state correctly (Technicolor)

### DIFF
--- a/src/aiovodafone/api.py
+++ b/src/aiovodafone/api.py
@@ -214,7 +214,7 @@ class VodafoneStationTechnicolorApi(VodafoneStationCommonApi):
 
         devices_dict = {}
         for device in host_json["data"]["hostTbl"]:
-            connected = bool(device["active"])
+            connected = device["active"] == "true"
             connection_type = (
                 "WiFi" if "WiFi" in device["layer1interface"] else "Ethernet"
             )


### PR DESCRIPTION
The code assumed bool() would parse string values, which led to always connected devices. Now the comparison to true yields the correct results.