### PR TITLE
Make library_test.py accept JSON config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,6 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+
+# Optional config file with router configuration for test script
+library_test.json

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,7 @@
       "type": "python",
       "request": "launch",
       "program": "library_test.py",
-      "args": ["-f", "library_test.json"],
+      "args": ["-cf", "library_test.json"],
       "console": "integratedTerminal",
       "justMyCode": true
     }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,7 @@
       "type": "python",
       "request": "launch",
       "program": "library_test.py",
-      "args": ["-p", "<your password>"],
+      "args": ["-f", "library_test.json"],
       "console": "integratedTerminal",
       "justMyCode": true
     }

--- a/library_test.py
+++ b/library_test.py
@@ -34,7 +34,7 @@ def get_arguments() -> tuple[argparse.ArgumentParser, argparse.Namespace]:
     parser.add_argument("--password", "-p", type=str, help="Set router password")
     parser.add_argument(
         "--configfile",
-        "-f",
+        "-cf",
         type=str,
         help="Load options from JSON config file. Command line options override those in the file.",
     )

--- a/library_test.py
+++ b/library_test.py
@@ -1,6 +1,8 @@
 import argparse
 import asyncio
+import json
 import logging
+import os
 
 import aiohttp
 
@@ -30,8 +32,21 @@ def get_arguments() -> tuple[argparse.ArgumentParser, argparse.Namespace]:
         "--username", "-u", type=str, default="vodafone", help="Set router username"
     )
     parser.add_argument("--password", "-p", type=str, help="Set router password")
+    parser.add_argument(
+        "--configfile",
+        "-f",
+        type=str,
+        help="Load options from JSON config file. Command line options override those in the file.",
+    )
 
     arguments = parser.parse_args()
+    if arguments.configfile:
+        # Re-parse the command line, taking the options in the optional JSON file as a basis
+        if os.path.exists(arguments.configfile):
+            with open(arguments.configfile) as f:
+                arguments = parser.parse_args(
+                    namespace=argparse.Namespace(**json.load(f))
+                )
 
     return parser, arguments
 
@@ -42,6 +57,7 @@ async def main() -> None:
 
     if not args.password:
         print("You have to specify a password")
+        parser.print_help()
         exit(1)
 
     print("Determining device type")


### PR DESCRIPTION
Make `library_test.py` accept configuration options from a JSON config file. The file contains the same options that can also be passed on the command line. Options specified on the command line always override those in the file.

The file could look like this:
```json
{
    "router": "192.168.100.1",
    "username": "admin",
    "password": "your_password"
}
```

In addition, exclude `library_test.json` from Git via `.gitignore`, this makes it a little easier for developers with diverging IP/username/password settings.

Reopened the pull request with a new name for the branch to see if that's what's blocking CI.