### PR TITLE
feat: detect Arris devices, even if we cannot support them

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,19 @@ Install this via pip (or your favourite package manager):
 
 `pip install aiovodafone`
 
+## Device Support
+
+The library currently supports Vodafone Stations by the following manufacturers:
+
+- Sercomm (includes devices with identical firmware by Huawei and ADB)
+- Technicolor
+
+The library does not support Vodafone Stations by the following manufacturers, but is capable of identifying them:
+
+- Arris (German Vodafone Station TG3442DE)
+
+Device support is limited by a Home Assistant restriction that supported devices not require web scraping, except for login.
+
 ## Contributors ✨
 
 Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):

--- a/library_test.py
+++ b/library_test.py
@@ -73,6 +73,9 @@ async def main() -> None:
         api = VodafoneStationTechnicolorApi(args.router, args.username, args.password)
     elif device_type == DeviceType.SERCOMM:
         api = VodafoneStationSercommApi(args.router, args.username, args.password)
+    elif device_type == DeviceType.ARRIS:
+        print("Arris devices are not supported by aiovodafone.")
+        exit(1)
     else:
         print("The device is not a supported Vodafone Station.")
         exit(1)

--- a/src/aiovodafone/api.py
+++ b/src/aiovodafone/api.py
@@ -73,6 +73,12 @@ class VodafoneStationCommonApi(ABC):
                 # There's no other sure way to identify a Sercomm device without login
                 if "var csrf_token = " in await response.text():
                     return DeviceType.SERCOMM
+        async with session.get(f"http://{host}/index.php", headers=HEADERS) as response:
+            if response.status == 200:
+                if "_ga.swVersion = " in await response.text():
+                    # Arris modems are unsupported by the library, but we can
+                    # at least detect them
+                    return DeviceType.ARRIS
         return None
 
     def __init__(self, host: str, username: str, password: str) -> None:

--- a/src/aiovodafone/const.py
+++ b/src/aiovodafone/const.py
@@ -25,3 +25,4 @@ USER_ALREADY_LOGGED_IN = "MSG_LOGIN_150"
 class DeviceType(str, Enum):
     SERCOMM = "Sercomm"
     TECHNICOLOR = "Technicolor"
+    ARRIS = "Arris"


### PR DESCRIPTION
Vodafone is selling some Stations based on Arris routers. This includes the model TG3442DE sold by Vodafone Germany.  #81 was meant to include support for this. However, the Arris firmware requires getting values from an API endpoint that packages them as JavaScript for the web browser, and Home Assistant has a restriction that Core integrations [must not use web scraping](https://github.com/home-assistant/architecture/blob/master/adr%2F0004-webscraping.md), except for login. 

After discussion in the Home Assistant discord, it was found that it is better not to add support for Arris modems in the library, in order not to threaten the existing Vodafone Station Core integration with removal. 

This PR adds support for at least **detecting** Arris modems instead, so that clients can react gracefully. 