### PR TITLE
build: uv version management with renovate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,10 +60,9 @@ jobs:
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Get UV version
+      - name: Extract UV version
         run: |
-          UV_VERSION=$(grep 'version =' pyproject.toml | sed -E 's/.*"([^"]+)".*/\1/')
-          echo "UV_VERSION=$UV_VERSION" >> $GITHUB_ENV
+          echo "UV_VERSION=$(./scripts/get-pyproject-uv.version.sh)" >> "$GITHUB_ENV"
       - name: Setup UV
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,6 @@ on:
       - main
   pull_request:
 
-env:
-  UV_VERSION: "0.11.24" # renovate: depName=uv datasource=pypi
-
 permissions: write-all
 
 concurrency:
@@ -55,14 +52,20 @@ jobs:
           - macOS-latest
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           persist-credentials: false
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+      - name: Get UV version
+        run: |
+          UV_VERSION=$(grep 'version =' pyproject.toml | sed -E 's/.*"([^"]+)".*/\1/')
+          echo "UV_VERSION=$UV_VERSION" >> $GITHUB_ENV
+      - name: Setup UV
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           version: ${{ env.UV_VERSION }}
       - name: Sync Dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,13 +40,17 @@ dev = [
     "pytest-cov>=5,<8"
 ]
 
+[tool.uv-version]
+# Source of truth for the uv version. All other version references must be derived from this value.
+version = "0.11.24" # renovate: depName=uv datasource=pypi
+
 [tool.semantic_release]
 version_toml = ["pyproject.toml:project.version"]
 version_variables = ["src/aiovodafone/__init__.py:__version__",]
 
 # Keep this version in sync with scripts/setup.sh and .github/workflows/ci.yml.
 build_command = """
-    UV_VERSION=$(grep 'UV_VERSION:' .github/workflows/ci.yml | sed -E 's/.*"([^"]+)".*/\\1/')
+    UV_VERSION=$(grep 'version =' pyproject.toml | sed -E 's/.*"([^"]+)".*/\\1/')
     python -m pip install "uv==$UV_VERSION"
     uv lock --upgrade-package "$PACKAGE_NAME"
     git add uv.lock

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ version_variables = ["src/aiovodafone/__init__.py:__version__",]
 
 # Keep this version in sync with scripts/setup.sh and .github/workflows/ci.yml.
 build_command = """
-    UV_VERSION=$(grep 'version =' pyproject.toml | sed -E 's/.*"([^"]+)".*/\\1/')
+    UV_VERSION=$(./scripts/get-pyproject-uv.version.sh)
     python -m pip install "uv==$UV_VERSION"
     uv lock --upgrade-package "$PACKAGE_NAME"
     git add uv.lock

--- a/scripts/get-pyproject-uv.version.sh
+++ b/scripts/get-pyproject-uv.version.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# Find the absolute path of the directory where this script resides
+SCRIPT_DIR=$(cd -- "$(dirname -- "$0")" &>/dev/null && pwd)
+
+# Go up one level to reach the repository root directory
+REPO_ROOT=$(dirname "$SCRIPT_DIR")
+
+# Isolate the [tool.uv-version] block and extract the clean version string
+sed -n '/\[tool.uv-version\]/,/version =/p' "$REPO_ROOT/pyproject.toml" | grep 'version =' | sed -E 's/.*version = "([^"]+)".*/\1/' | tr -d '\r' | xargs

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -7,8 +7,8 @@ set -e
 # Use copy mode for UV to avoid hardlink warnings on different filesystems
 export UV_LINK_MODE=copy
 
-# Only source of truth is pyproject.toml, so we extract the version from there
-UV_VERSION=$(grep 'version =' pyproject.toml | sed -E 's/.*"([^"]+)".*/\1/')
+# Fetch the centralized uv version from the companion script
+UV_VERSION=$(./scripts/get-pyproject-uv.version.sh)
 
 if ! uv --version 2>/dev/null; then
     pipx install "uv==$UV_VERSION"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -7,8 +7,8 @@ set -e
 # Use copy mode for UV to avoid hardlink warnings on different filesystems
 export UV_LINK_MODE=copy
 
-# Estrae la versione di UV direttamente dal file di configurazione della CI
-UV_VERSION=$(grep 'UV_VERSION:' .github/workflows/ci.yml | sed -E 's/.*"([^"]+)".*/\1/')
+# Only source of truth is pyproject.toml, so we extract the version from there
+UV_VERSION=$(grep 'version =' pyproject.toml | sed -E 's/.*"([^"]+)".*/\1/')
 
 if ! uv --version 2>/dev/null; then
     pipx install "uv==$UV_VERSION"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CI and release automation now use a single shared version value, reducing the chance of mismatched tool versions across checks and builds.
  * Setup steps dynamically read the current version at runtime, improving consistency without changing the test flow.

* **Chores**
  * Updated project configuration to keep version information in one place for easier maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->