### PR TITLE
fix: login expired may redirect to login page

### DIFF
--- a/src/aiovodafone/api.py
+++ b/src/aiovodafone/api.py
@@ -130,7 +130,7 @@ class VodafoneStationCommonApi(ABC):
                         login_page,
                     )
                     raise CannotAuthenticate(
-                        "Client response redirect to login page '%s'", login_page
+                        f"Client response redirect to login page '{login_page}'"
                     ) from None
 
                 _LOGGER.warning(

--- a/src/aiovodafone/api.py
+++ b/src/aiovodafone/api.py
@@ -19,6 +19,7 @@ from yarl import URL
 from .const import (
     _LOGGER,
     DEFAULT_TIMEOUT,
+    DEVICES_SETTINGS,
     HEADERS,
     REQUEST_ALLOW_REDIRECTS,
     REQUEST_SUPPRESS_LOG,
@@ -27,6 +28,7 @@ from .const import (
     WifiType,
 )
 from .exceptions import (
+    CannotAuthenticate,
     GenericResponseError,
 )
 
@@ -46,6 +48,9 @@ class VodafoneStationDevice:
 
 class VodafoneStationCommonApi(ABC):
     """Common API calls for Vodafone Station routers."""
+
+    device_type: str
+    """String identifying the device type. Must be a valid key in DEVICES_SETTINGS."""
 
     def __init__(
         self,
@@ -120,6 +125,23 @@ class VodafoneStationCommonApi(ABC):
                 )
                 raise GenericResponseError
         except ClientResponseError as err:
+            login_page = f"/{DEVICES_SETTINGS[self.device_type]['login_url']}"
+            if (
+                err.status == HTTPStatus.FOUND
+                and err.headers
+                and err.headers.get("Location") == login_page
+            ):
+                _LOGGER.debug(
+                    "%s page %s from host %s redirects to login page '%s'",
+                    method,
+                    page,
+                    self.base_url.host,
+                    login_page,
+                )
+                raise CannotAuthenticate(
+                    "Client response redirect to login page '%s'", login_page
+                ) from err
+
             # Some models return text replies with invalid HTML headers.
             # Suppress expected errors to prevent log spam.
             if not suppress_log:

--- a/src/aiovodafone/api.py
+++ b/src/aiovodafone/api.py
@@ -116,6 +116,23 @@ class VodafoneStationCommonApi(ABC):
                 allow_redirects=allow_redirects,
             )
             if response.status != HTTPStatus.OK:
+                login_page = f"/{DEVICES_SETTINGS[self.device_type]['login_url']}"
+                if (
+                    response.status == HTTPStatus.FOUND
+                    and response.headers
+                    and response.headers.get("Location") == login_page
+                ):
+                    _LOGGER.debug(
+                        "%s page %s from host %s redirects to login page '%s'",
+                        method,
+                        page,
+                        self.base_url.host,
+                        login_page,
+                    )
+                    raise CannotAuthenticate(
+                        "Client response redirect to login page '%s'", login_page
+                    ) from None
+
                 _LOGGER.warning(
                     "%s page %s from host %s failed: %s",
                     method,
@@ -125,23 +142,6 @@ class VodafoneStationCommonApi(ABC):
                 )
                 raise GenericResponseError
         except ClientResponseError as err:
-            login_page = f"/{DEVICES_SETTINGS[self.device_type]['login_url']}"
-            if (
-                err.status == HTTPStatus.FOUND
-                and err.headers
-                and err.headers.get("Location") == login_page
-            ):
-                _LOGGER.debug(
-                    "%s page %s from host %s redirects to login page '%s'",
-                    method,
-                    page,
-                    self.base_url.host,
-                    login_page,
-                )
-                raise CannotAuthenticate(
-                    "Client response redirect to login page '%s'", login_page
-                ) from err
-
             # Some models return text replies with invalid HTML headers.
             # Suppress expected errors to prevent log spam.
             if not suppress_log:

--- a/src/aiovodafone/api.py
+++ b/src/aiovodafone/api.py
@@ -22,6 +22,7 @@ from yarl import URL
 from .const import (
     _LOGGER,
     DEFAULT_TIMEOUT,
+    DEVICES_SETTINGS,
     HEADERS,
     REQUEST_ALLOW_REDIRECTS,
     REQUEST_SUPPRESS_LOG,
@@ -30,6 +31,7 @@ from .const import (
     WifiType,
 )
 from .exceptions import (
+    CannotAuthenticate,
     GenericResponseError,
 )
 
@@ -49,6 +51,9 @@ class VodafoneStationDevice:
 
 class VodafoneStationCommonApi(ABC):
     """Common API calls for Vodafone Station routers."""
+
+    device_type: str
+    """Device type, must be a valid key in DEVICES_SETTINGS."""
 
     def __init__(
         self,
@@ -114,13 +119,22 @@ class VodafoneStationCommonApi(ABC):
                 allow_redirects=allow_redirects,
             )
             if response.status != HTTPStatus.OK:
-                _LOGGER.warning(
-                    "%s page %s from host %s failed: %s",
-                    method,
-                    page,
-                    self.base_url.host,
-                    response.status,
-                )
+                context = f"{method} page {page} from host {self.base_url.host}"
+                login_page = f"/{DEVICES_SETTINGS[self.device_type]['login_url']}"
+                if (
+                    response.status == HTTPStatus.FOUND
+                    and response.headers.get("Location") == login_page
+                ):
+                    _LOGGER.debug(
+                        "%s redirects to login page '%s'", context, login_page
+                    )
+                    raise CannotAuthenticate(
+                        f"{context} redirects to login page '{login_page}'"
+                    ) from None
+                if response.status == HTTPStatus.UNAUTHORIZED:
+                    _LOGGER.debug("%s returned 401", context)
+                    raise CannotAuthenticate(f"{context} returned 401") from None
+                _LOGGER.warning("%s failed: %s", context, response.status)
                 raise GenericResponseError
         except ClientResponseError as err:
             # Some models return text replies with invalid HTML headers.

--- a/src/aiovodafone/models/homeware.py
+++ b/src/aiovodafone/models/homeware.py
@@ -196,6 +196,8 @@ class VodafoneStationHomewareApi(VodafoneStationCommonApi):
      - UK VOX 3.0 (THG3000) - firmware v19
     """
 
+    device_type = "Homeware"
+
     async def _get_csrf_token(self) -> str:
         """Fetch CSRF token from the router."""
         _LOGGER.debug("Fetching CSRF token")

--- a/src/aiovodafone/models/homeware.py
+++ b/src/aiovodafone/models/homeware.py
@@ -199,6 +199,8 @@ class VodafoneStationHomewareApi(VodafoneStationCommonApi):
      - UK VOX 3.0 (THG3000) - firmware v19
     """
 
+    device_type = "Homeware"
+
     async def _get_csrf_token(self) -> str:
         """Fetch CSRF token from the router."""
         _LOGGER.debug("Fetching CSRF token")

--- a/src/aiovodafone/models/sercomm.py
+++ b/src/aiovodafone/models/sercomm.py
@@ -44,6 +44,8 @@ from aiovodafone.sjcl import SJCL, build_json_from_sjcl
 class VodafoneStationSercommApi(VodafoneStationCommonApi):
     """Queries Vodafone Station running Sercomm firmware."""
 
+    device_type = "Sercomm"
+
     def __init__(
         self,
         url: URL,

--- a/src/aiovodafone/models/sercomm.py
+++ b/src/aiovodafone/models/sercomm.py
@@ -47,6 +47,8 @@ from aiovodafone.sjcl import SJCL, build_json_from_sjcl
 class VodafoneStationSercommApi(VodafoneStationCommonApi):
     """Queries Vodafone Station running Sercomm firmware."""
 
+    device_type = "Sercomm"
+
     def __init__(
         self,
         url: URL,

--- a/src/aiovodafone/models/technicolor.py
+++ b/src/aiovodafone/models/technicolor.py
@@ -16,6 +16,8 @@ from aiovodafone.exceptions import AlreadyLogged, CannotAuthenticate, ResultTime
 class VodafoneStationTechnicolorApi(VodafoneStationCommonApi):
     """Queries Vodafone Station running Technicolor firmware."""
 
+    device_type = "Technicolor"
+
     async def _encrypt_string(
         self,
         credential: str,

--- a/src/aiovodafone/models/technicolor.py
+++ b/src/aiovodafone/models/technicolor.py
@@ -19,6 +19,8 @@ from aiovodafone.exceptions import AlreadyLogged, CannotAuthenticate, ResultTime
 class VodafoneStationTechnicolorApi(VodafoneStationCommonApi):
     """Queries Vodafone Station running Technicolor firmware."""
 
+    device_type = "Technicolor"
+
     async def _encrypt_string(
         self,
         credential: str,

--- a/src/aiovodafone/models/ultrahub.py
+++ b/src/aiovodafone/models/ultrahub.py
@@ -33,6 +33,8 @@ from aiovodafone.sjcl import SJCL, build_json_from_sjcl
 class VodafoneStationUltraHubApi(VodafoneStationCommonApi):
     """Queries Vodafone Ultra Hub."""
 
+    device_type = "UltraHub"
+
     def __init__(
         self, url: URL, username: str, password: str, session: ClientSession
     ) -> None:

--- a/src/aiovodafone/models/ultrahub.py
+++ b/src/aiovodafone/models/ultrahub.py
@@ -36,6 +36,8 @@ from aiovodafone.sjcl import SJCL, build_json_from_sjcl
 class VodafoneStationUltraHubApi(VodafoneStationCommonApi):
     """Queries Vodafone Ultra Hub."""
 
+    device_type = "UltraHub"
+
     def __init__(
         self, url: URL, username: str, password: str, session: ClientSession
     ) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 import pytest
@@ -47,6 +47,7 @@ class FakeResponse:
     json_data: object | None = None
     content_type: str = "application/json"
     cookies: dict[str, object] | None = None
+    headers: dict[str, str] = field(default_factory=dict)
 
     async def text(self) -> str:
         """Return configured plain-text payload."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 import pytest
@@ -50,6 +50,7 @@ class FakeResponse:
     json_data: object | None = None
     content_type: str = "application/json"
     cookies: dict[str, object] | None = None
+    headers: dict[str, str] = field(default_factory=dict)
 
     async def text(self) -> str:
         """Return configured plain-text payload."""

--- a/tests/test_api_base.py
+++ b/tests/test_api_base.py
@@ -12,7 +12,7 @@ import pytest
 from aiohttp import ClientResponseError
 
 from aiovodafone.api import VodafoneStationCommonApi, VodafoneStationDevice
-from aiovodafone.exceptions import GenericResponseError
+from aiovodafone.exceptions import CannotAuthenticate, GenericResponseError
 from tests.conftest import FakeCookieJar, FakeResponse, FakeSession
 
 if TYPE_CHECKING:
@@ -21,6 +21,8 @@ if TYPE_CHECKING:
 
 class DummyCommonApi(VodafoneStationCommonApi):
     """Concrete test double for exercising common API base helpers."""
+
+    device_type = "Sercomm"
 
     def convert_uptime(self, _uptime: str) -> datetime:
         """Return a timezone-aware datetime for abstract method compliance."""
@@ -131,6 +133,27 @@ def test_request_page_result_client_response_error_raises(base_url: URL) -> None
         base_url, "u", "p", cast("Any", FakeSession(request_impl=_request))
     )
     with pytest.raises(GenericResponseError):
+        asyncio.run(_acall(api, "_request_page_result", HTTPMethod.GET, "status"))
+
+
+def test_request_page_result_login_redirect_raises_cannot_authenticate(
+    base_url: URL,
+) -> None:
+    """Verify request helper detects a login-page redirect and re-authenticates."""
+
+    async def _request(*_args: object, **_kwargs: object) -> FakeResponse:
+        raise ClientResponseError(
+            cast("Any", SimpleNamespace(real_url="http://router.local")),
+            (),
+            status=302,
+            message="Found",
+            headers={"Location": "/login.html"},
+        )
+
+    api = DummyCommonApi(
+        base_url, "u", "p", cast("Any", FakeSession(request_impl=_request))
+    )
+    with pytest.raises(CannotAuthenticate):
         asyncio.run(_acall(api, "_request_page_result", HTTPMethod.GET, "status"))
 
 

--- a/tests/test_api_base.py
+++ b/tests/test_api_base.py
@@ -12,6 +12,7 @@ import pytest
 from aiohttp import ClientResponseError
 
 from aiovodafone.api import VodafoneStationCommonApi, VodafoneStationDevice
+from aiovodafone.const import DEVICES_SETTINGS
 from aiovodafone.exceptions import CannotAuthenticate, GenericResponseError
 from tests.conftest import FakeCookieJar, FakeResponse, FakeSession
 
@@ -140,20 +141,18 @@ def test_request_page_result_login_redirect_raises_cannot_authenticate(
     base_url: URL,
 ) -> None:
     """Verify request helper detects a login-page redirect and re-authenticates."""
+    login_page = f"/{DEVICES_SETTINGS[DummyCommonApi.device_type]['login_url']}"
 
     async def _request(*_args: object, **_kwargs: object) -> FakeResponse:
-        raise ClientResponseError(
-            cast("Any", SimpleNamespace(real_url="http://router.local")),
-            (),
-            status=302,
-            message="Found",
-            headers={"Location": "/login.html"},
-        )
+        return FakeResponse(status=302, headers={"Location": login_page})
 
     api = DummyCommonApi(
         base_url, "u", "p", cast("Any", FakeSession(request_impl=_request))
     )
-    with pytest.raises(CannotAuthenticate):
+    with pytest.raises(
+        CannotAuthenticate,
+        match=f"Client response redirect to login page '{login_page}'",
+    ):
         asyncio.run(_acall(api, "_request_page_result", HTTPMethod.GET, "status"))
 
 

--- a/tests/test_api_base.py
+++ b/tests/test_api_base.py
@@ -15,7 +15,8 @@ import pytest
 from aiohttp import ClientResponseError
 
 from aiovodafone.api import VodafoneStationCommonApi, VodafoneStationDevice
-from aiovodafone.exceptions import GenericResponseError
+from aiovodafone.const import DEVICES_SETTINGS
+from aiovodafone.exceptions import CannotAuthenticate, GenericResponseError
 from tests.conftest import FakeCookieJar, FakeResponse, FakeSession
 
 if TYPE_CHECKING:
@@ -24,6 +25,8 @@ if TYPE_CHECKING:
 
 class DummyCommonApi(VodafoneStationCommonApi):
     """Concrete test double for exercising common API base helpers."""
+
+    device_type = "Sercomm"
 
     def convert_uptime(self, _uptime: str) -> datetime:
         """Return a timezone-aware datetime for abstract method compliance."""
@@ -116,6 +119,38 @@ def test_request_page_result_non_200_raises(base_url: URL) -> None:
         base_url, "u", "p", cast("Any", FakeSession(request_impl=_request))
     )
     with pytest.raises(GenericResponseError):
+        asyncio.run(_acall(api, "_request_page_result", HTTPMethod.GET, "status"))
+
+
+def test_request_page_result_login_redirect_raises_cannot_authenticate(
+    base_url: URL,
+) -> None:
+    """Verify a 302 redirect to the login page is treated as an auth failure."""
+    login_page = f"/{DEVICES_SETTINGS[DummyCommonApi.device_type]['login_url']}"
+
+    async def _request(*_args: object, **_kwargs: object) -> FakeResponse:
+        return FakeResponse(status=302, headers={"Location": login_page})
+
+    api = DummyCommonApi(
+        base_url, "u", "p", cast("Any", FakeSession(request_impl=_request))
+    )
+    with pytest.raises(
+        CannotAuthenticate,
+        match=f"redirects to login page '{login_page}'",
+    ):
+        asyncio.run(_acall(api, "_request_page_result", HTTPMethod.GET, "status"))
+
+
+def test_request_page_result_401_raises_cannot_authenticate(base_url: URL) -> None:
+    """Verify a bare 401 (expired session) is treated as an auth failure."""
+
+    async def _request(*_args: object, **_kwargs: object) -> FakeResponse:
+        return FakeResponse(status=401)
+
+    api = DummyCommonApi(
+        base_url, "u", "p", cast("Any", FakeSession(request_impl=_request))
+    )
+    with pytest.raises(CannotAuthenticate, match="returned 401"):
         asyncio.run(_acall(api, "_request_page_result", HTTPMethod.GET, "status"))
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication error handling when requests are redirected to a login page or return an unauthorized response.
  * Added clearer context for failed requests and authentication-related errors.
* **Compatibility**
  * Improved authentication handling across supported Vodafone Station device models, including Homeware, Sercomm, Technicolor, and UltraHub.
* **Tests**
  * Added coverage for login redirects, unauthorized responses, and device-specific authentication behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->