### PR TITLE
feat: add Huawei (PT Vodafone ONT) device support

### DIFF
--- a/src/aiovodafone/const.py
+++ b/src/aiovodafone/const.py
@@ -61,6 +61,10 @@ DEVICES_SETTINGS: dict[str, Any] = {
         "params": {"X_INTERNAL_FIELDS": "X_VODAFONE_ServiceStatus_1"},
         "default_id": 3,
     },
+    "Huawei": {
+        # Root login page contains productName / GetRandCount.asp markers.
+        "login_url": "",
+    },
 }
 
 DEVICE_SERCOMM_LOGIN_STATUS = [

--- a/src/aiovodafone/models/__init__.py
+++ b/src/aiovodafone/models/__init__.py
@@ -59,11 +59,11 @@ class_registry: dict[DeviceType, type[VodafoneStationCommonApi]] = {
 def init_device_class(
     url: URL, device_type: DeviceType, data: Mapping[str, Any], session: ClientSession
 ) -> VodafoneStationCommonApi:
-    """Return inited API class."""
+    """Return the inited API class."""
     if device_type not in class_registry:
         raise ModelNotSupported(f"Device type '{device_type}' not supported")
-
     api_class: type[VodafoneStationCommonApi] = class_registry[device_type]
+
     return api_class(
         url,
         data["username"],
@@ -76,30 +76,34 @@ async def get_device_type(
     host: str,
     session: ClientSession,
 ) -> tuple[DeviceType, URL]:
-    """Find out what kind of device we are talking to.
+    """Find out the device type of a Vodafone Stations and returns it as enum.
 
-    The detection is based on the content of the response for a specific url
-    available for each device type:
-    - Technicolor devices return a JSON response with a ``data`` dictionary
-      containing a ``ModelName`` key.
-    - UltraHub devices return a JSON response containing a
-      ``X_VODAFONE_ServiceStatus_1`` key.
-    - Sercomm devices return an HTML response containing a ``csrf_token``
-      JavaScript variable.
-    - Homeware devices return a JSON response with ``status`` field set to
-      ``alive``.
+    - The Technicolor devices always answer with a valid HTTP response, the
+
+    - Sercomm returns 404 on a missing page. This helps to determine which we are
+      talking with.
+      For detecting the Sercomm devices, a look up for a CSRF token is used.
+
+    - The UltraHub is identified by a specific key in the JSON response.
+
+    - The Homeware devices return a JSON response with a ``status`` field set to
+    ``alive``.
     - Huawei (PT Vodafone ONT) devices return the root login HTML containing
       ``login.cgi`` and ``GetRandCount.asp``.
 
     Args:
     ----
         host (str): The router's address, e.g. `192.168.1.1`
-        session (ClientSession): The client session for HTTP requests
+        session (ClientSession): the client session for HTTP requests
 
     Returns:
     -------
-        device_type: returns the enum entry in DeviceType or raises `ModelNotSupported`
-        url: the full router url with scheme and host, e.g. `http://192.168.1.1`
+    [
+        device_type:
+            returns an enum entry in DeviceType or raises `ModelNotSupported`
+        url:
+            full router url with scheme and host, e.g. `http://192.168.1.1`
+    ]
 
     """
     for device_info in DEVICES_SETTINGS.values():
@@ -133,13 +137,16 @@ async def get_device_type(
                             "Detected device type: %s", DeviceType.TECHNICOLOR
                         )
                         return (DeviceType.TECHNICOLOR, return_url)
+
                     if "X_VODAFONE_ServiceStatus_1" in response_json:
-                        session.cookie_jar.clear()  # Needed to cleanup the session
+                        session.cookie_jar.clear()  # Needed to cleanup session
                         _LOGGER.debug("Detected device type: %s", DeviceType.ULTRAHUB)
                         return (DeviceType.ULTRAHUB, return_url)
-                    if "var csrf_token =" in response_text:
+
+                    if "var csrf_token = " in response_text:
                         _LOGGER.debug("Detected device type: %s", DeviceType.SERCOMM)
                         return (DeviceType.SERCOMM, return_url)
+
                     if response_json.get("status") == "alive":
                         _LOGGER.debug("Detected device type: %s", DeviceType.HOMEWARE)
                         return (DeviceType.HOMEWARE, return_url)

--- a/src/aiovodafone/models/__init__.py
+++ b/src/aiovodafone/models/__init__.py
@@ -21,6 +21,7 @@ from aiovodafone.const import _LOGGER, DEVICES_SETTINGS, HEADERS
 from aiovodafone.exceptions import ModelNotSupported
 
 from .homeware import VodafoneStationHomewareApi
+from .huawei import VodafoneStationHuaweiApi
 from .sercomm import VodafoneStationSercommApi
 from .technicolor import VodafoneStationTechnicolorApi
 from .ultrahub import VodafoneStationUltraHubApi
@@ -33,6 +34,7 @@ class DeviceType(StrEnum):
     SERCOMM = "Sercomm"
     TECHNICOLOR = "Technicolor"
     ULTRAHUB = "UltraHub"
+    HUAWEI = "Huawei"
 
 
 class_registry: dict[DeviceType, type[VodafoneStationCommonApi]] = {
@@ -48,17 +50,20 @@ class_registry: dict[DeviceType, type[VodafoneStationCommonApi]] = {
     DeviceType.ULTRAHUB: cast(
         "type[VodafoneStationCommonApi]", VodafoneStationUltraHubApi
     ),
+    DeviceType.HUAWEI: cast(
+        "type[VodafoneStationCommonApi]", VodafoneStationHuaweiApi
+    ),
 }
 
 
 def init_device_class(
     url: URL, device_type: DeviceType, data: Mapping[str, Any], session: ClientSession
 ) -> VodafoneStationCommonApi:
-    """Return the inited API class."""
+    """Return inited API class."""
     if device_type not in class_registry:
         raise ModelNotSupported(f"Device type '{device_type}' not supported")
-    api_class: type[VodafoneStationCommonApi] = class_registry[device_type]
 
+    api_class: type[VodafoneStationCommonApi] = class_registry[device_type]
     return api_class(
         url,
         data["username"],
@@ -71,32 +76,30 @@ async def get_device_type(
     host: str,
     session: ClientSession,
 ) -> tuple[DeviceType, URL]:
-    """Find out the device type of a Vodafone Stations and returns it as enum.
+    """Find out what kind of device we are talking to.
 
-    - The Technicolor devices always answer with a valid HTTP response, the
-
-    - Sercomm returns 404 on a missing page. This helps to determine which we are
-      talking with.
-      For detecting the Sercomm devices, a look up for a CSRF token is used.
-
-    - The UltraHub is identified by a specific key in the JSON response.
-
-    - The Homeware devices return a JSON response with a ``status`` field set to
-    ``alive``.
+    The detection is based on the content of the response for a specific url
+    available for each device type:
+    - Technicolor devices return a JSON response with a ``data`` dictionary
+      containing a ``ModelName`` key.
+    - UltraHub devices return a JSON response containing a
+      ``X_VODAFONE_ServiceStatus_1`` key.
+    - Sercomm devices return an HTML response containing a ``csrf_token``
+      JavaScript variable.
+    - Homeware devices return a JSON response with ``status`` field set to
+      ``alive``.
+    - Huawei (PT Vodafone ONT) devices return the root login HTML containing
+      ``login.cgi`` and ``GetRandCount.asp``.
 
     Args:
     ----
         host (str): The router's address, e.g. `192.168.1.1`
-        session (ClientSession): the client session for HTTP requests
+        session (ClientSession): The client session for HTTP requests
 
     Returns:
     -------
-    [
-        device_type:
-            returns an enum entry in DeviceType or raises `ModelNotSupported`
-        url:
-            full router url with scheme and host, e.g. `http://192.168.1.1`
-    ]
+        device_type: returns the enum entry in DeviceType or raises `ModelNotSupported`
+        url: the full router url with scheme and host, e.g. `http://192.168.1.1`
 
     """
     for device_info in DEVICES_SETTINGS.values():
@@ -130,19 +133,22 @@ async def get_device_type(
                             "Detected device type: %s", DeviceType.TECHNICOLOR
                         )
                         return (DeviceType.TECHNICOLOR, return_url)
-
                     if "X_VODAFONE_ServiceStatus_1" in response_json:
-                        session.cookie_jar.clear()  # Needed to cleanup session
+                        session.cookie_jar.clear()  # Needed to cleanup the session
                         _LOGGER.debug("Detected device type: %s", DeviceType.ULTRAHUB)
                         return (DeviceType.ULTRAHUB, return_url)
-
-                    if "var csrf_token = " in response_text:
+                    if "var csrf_token =" in response_text:
                         _LOGGER.debug("Detected device type: %s", DeviceType.SERCOMM)
                         return (DeviceType.SERCOMM, return_url)
-
                     if response_json.get("status") == "alive":
                         _LOGGER.debug("Detected device type: %s", DeviceType.HOMEWARE)
                         return (DeviceType.HOMEWARE, return_url)
+                    if (
+                        "login.cgi" in response_text
+                        and "GetRandCount.asp" in response_text
+                    ):
+                        _LOGGER.debug("Detected device type: %s", DeviceType.HUAWEI)
+                        return (DeviceType.HUAWEI, return_url)
 
             except (
                 ClientConnectorSSLError,

--- a/src/aiovodafone/models/huawei.py
+++ b/src/aiovodafone/models/huawei.py
@@ -1,0 +1,699 @@
+# Copyright 2023 Simone Chemelli and contributors
+# SPDX-License-Identifier: Apache-2.0
+"""Huawei (PT Vodafone) ONT / Station model API implementation."""
+
+from __future__ import annotations
+
+import base64
+import contextlib
+import re
+from datetime import UTC, datetime, timedelta
+from http import HTTPMethod, HTTPStatus
+from typing import Any
+from urllib.parse import urlencode
+
+import aiohttp
+from aiohttp import ClientResponseError, ClientSession
+from yarl import URL
+
+from aiovodafone.api import VodafoneStationCommonApi, VodafoneStationDevice
+from aiovodafone.const import (
+    _LOGGER,
+    DEFAULT_TIMEOUT,
+    POST_RESTART_TIMEOUT,
+    REQUEST_TIMEOUT,
+    WIFI_DATA,
+    WifiBand,
+    WifiType,
+)
+from aiovodafone.exceptions import (
+    CannotAuthenticate,
+    CannotConnect,
+    GenericLoginError,
+    GenericResponseError,
+)
+
+# WLANConfiguration instance mapping for PTVDF firmware.
+_WLAN_INDEX: dict[tuple[WifiType, WifiBand], int] = {
+    (WifiType.MAIN, WifiBand.BAND_2_4_GHZ): 1,
+    (WifiType.GUEST, WifiBand.BAND_2_4_GHZ): 2,
+    (WifiType.MAIN, WifiBand.BAND_5_GHZ): 5,
+    (WifiType.GUEST, WifiBand.BAND_5_GHZ): 6,
+}
+
+_WIFI_ENTRY_KEY: dict[tuple[WifiType, WifiBand], str] = {
+    (WifiType.MAIN, WifiBand.BAND_2_4_GHZ): "main",
+    (WifiType.GUEST, WifiBand.BAND_2_4_GHZ): "guest",
+    (WifiType.MAIN, WifiBand.BAND_5_GHZ): "main_5g",
+    (WifiType.GUEST, WifiBand.BAND_5_GHZ): "guest_5g",
+}
+
+_BEACON_SECURITY = {
+    "11i": "WPA2",
+    "WPAand11i": "WPA",
+    "WPA3": "WPA3",
+    "11iandWPA3": "WPA2",
+    "Basic": "WEP",
+    "None": "nopass",
+}
+
+_USER_DEVICE_FIELDS = (
+    "Domain",
+    "IpAddr",
+    "MacAddr",
+    "Port",
+    "IpType",
+    "DevType",
+    "DevStatus",
+    "PortType",
+    "Time",
+    "HostName",
+    "IPv4Enabled",
+    "IPv6Enabled",
+    "DeviceType",
+    "UserDevAlias",
+    "UserSpecifiedDeviceType",
+    "LeaseTimeRemaining",
+    "RealMacAddr",
+)
+
+_HEX_ESCAPE_RE = re.compile(r"\\x([0-9a-fA-F]{2})")
+_UPTIME_RE = re.compile(
+    r"(?:(?P<days>\d+)\s*day(?:s)?\s*)?"
+    r"(?P<hours>\d{1,2}):(?P<minutes>\d{2})(?::(?P<seconds>\d{2}))?",
+    re.IGNORECASE,
+)
+_STRING_ARG_RE = re.compile(r'"((?:[^"\\]|\\.)*)"')
+_ONTTOKEN_RE = re.compile(
+    r"""(?:name|id)=["']onttoken["'][^>]*value=["']([^"']*)["']"""
+    r"""|value=["']([^"']*)["'][^>]*(?:name|id)=["']onttoken["']""",
+    re.I,
+)
+_PRODUCT_NAME_RE = re.compile(r"productName\s*=\s*'((?:\\x[0-9a-fA-F]{2}|[^'])*)'")
+_DEVICE_INFO_RE = re.compile(
+    r'new\s+stDeviceInfo\(\s*"([^"]*)"\s*,\s*"([^"]*)"\s*,\s*"([^"]*)"\s*\)'
+)
+_LINE_URI_RE = re.compile(r'new\s+stLineURI\(\s*"[^"]*"\s*,\s*"([^"]*)"\s*\)')
+_WAN_IP_RE = re.compile(r"new\s+WanIP\((.*?)\)\s*(?:,|;|\))", re.S)
+
+
+def _decode_js_string(value: str) -> str:
+    """Decode Huawei ASP ``\\xNN`` escapes and strip BOM."""
+    return _HEX_ESCAPE_RE.sub(lambda match: chr(int(match.group(1), 16)), value).lstrip(
+        "\ufeff"
+    )
+
+
+def _parse_ctor_args(args_blob: str) -> list[str]:
+    """Return decoded string arguments from a JS constructor call."""
+    return [_decode_js_string(match.group(1)) for match in _STRING_ARG_RE.finditer(args_blob)]
+
+
+def _parse_ctor_calls(script: str, ctor_name: str) -> list[list[str]]:
+    """Parse all ``new Ctor(...)`` calls with the given constructor name.
+
+    Matches the named constructor only (not outer ``new Array(...)`` wrappers),
+    so nested ``new stWlan(...)`` entries inside arrays are all found.
+    """
+    pattern = re.compile(
+        rf"new\s+{re.escape(ctor_name)}\((.*?)\)(?=\s*[,;)])",
+        re.S,
+    )
+    calls: list[list[str]] = []
+    for match in pattern.finditer(script):
+        args = _parse_ctor_args(match.group(1))
+        if args:
+            calls.append(args)
+    return calls
+
+
+def _wlan_instance(domain: str) -> int | None:
+    """Extract WLANConfiguration instance number from a TR-069 domain."""
+    match = re.search(r"WLANConfiguration\.(\d+)", domain)
+    if not match:
+        return None
+    return int(match.group(1))
+
+
+class VodafoneStationHuaweiApi(VodafoneStationCommonApi):
+    """Queries Huawei-based Vodafone Station / ONT web UI (PTVDF firmware)."""
+
+    def __init__(
+        self,
+        url: URL,
+        username: str,
+        password: str,
+        session: ClientSession,
+    ) -> None:
+        """Initialize Huawei API client."""
+        super().__init__(url, username, password, session)
+        self._session_cookie: str | None = None
+        self._product_name: str = ""
+        self._language: str = "english"
+
+    def convert_uptime(self, uptime: str) -> datetime:
+        """Convert Huawei uptime string to last-boot datetime.
+
+        Accepts:
+        - ``1 day(s) 05:09:51``
+        - ``05:09:51``
+        - integer seconds as string
+        """
+        cleaned = uptime.strip()
+        if cleaned.isdigit():
+            return datetime.now(tz=UTC) - timedelta(seconds=int(cleaned))
+
+        match = _UPTIME_RE.fullmatch(cleaned.replace("(s)", "s"))
+        if not match:
+            # Fallback: try day(s) prefix + h:m:s with flexible spacing
+            match = _UPTIME_RE.search(cleaned)
+        if not match:
+            _LOGGER.warning("Unable to parse Huawei uptime %r", uptime)
+            return datetime.now(tz=UTC)
+
+        days = int(match.group("days") or 0)
+        hours = int(match.group("hours") or 0)
+        minutes = int(match.group("minutes") or 0)
+        seconds = int(match.group("seconds") or 0)
+        return datetime.now(tz=UTC) - timedelta(
+            days=days, hours=hours, minutes=minutes, seconds=seconds
+        )
+
+    async def login(self, force_logout: bool = False) -> bool:  # noqa: ARG002
+        """Log into the router.
+
+        The one-time token from ``GetRandCount.asp`` is bound to the TCP
+        connection it was issued on. Token fetch and ``login.cgi`` are performed
+        on a dedicated single-connection session so they share a socket even when
+        the shared ClientSession uses a multi-connection pool.
+        """
+        _LOGGER.debug("Logging into %s", self.base_url.host)
+        self._session_cookie = None
+        self.csrf_token = ""
+
+        language = self._language or "english"
+        origin = str(self.base_url).rstrip("/")
+        connector = aiohttp.TCPConnector(limit=1, force_close=False)
+        try:
+            async with aiohttp.ClientSession(
+                connector=connector, cookie_jar=aiohttp.DummyCookieJar()
+            ) as login_session:
+                # Login page exposes productName used as model.
+                with contextlib.suppress(ClientResponseError, TimeoutError, AttributeError):
+                    login_page = await login_session.request(
+                        HTTPMethod.GET,
+                        self.base_url.joinpath(""),
+                        headers={
+                            "User-Agent": self.headers["User-Agent"],
+                            "Accept": "text/html,*/*",
+                            "Accept-Encoding": "identity",
+                        },
+                        timeout=DEFAULT_TIMEOUT,
+                        ssl=False,
+                        allow_redirects=False,
+                    )
+                    if login_page.status == HTTPStatus.OK:
+                        page_text = await login_page.text()
+                        product_match = _PRODUCT_NAME_RE.search(page_text)
+                        if product_match:
+                            self._product_name = _decode_js_string(
+                                product_match.group(1)
+                            )
+
+                try:
+                    token_response = await login_session.request(
+                        HTTPMethod.POST,
+                        self.base_url.joinpath("asp/GetRandCount.asp"),
+                        data=b"",
+                        headers={
+                            "User-Agent": self.headers["User-Agent"],
+                            "Accept": "*/*",
+                            "Accept-Encoding": "identity",
+                            "Origin": origin,
+                            "Referer": f"{origin}/",
+                            "X-Requested-With": "XMLHttpRequest",
+                            "Content-Length": "0",
+                        },
+                        timeout=DEFAULT_TIMEOUT,
+                        ssl=False,
+                        allow_redirects=False,
+                    )
+                except ClientResponseError as err:
+                    raise CannotConnect from err
+
+                if token_response.status != HTTPStatus.OK:
+                    raise CannotConnect(
+                        f"GetRandCount.asp failed with status {token_response.status}"
+                    )
+
+                token = (await token_response.text()).lstrip("\ufeff").strip()
+                if not token:
+                    raise GenericLoginError("Empty login token from GetRandCount.asp")
+
+                payload = urlencode(
+                    {
+                        "UserName": self.username,
+                        "PassWord": base64.b64encode(self.password.encode()).decode(),
+                        "Language": language,
+                        "x.X_HW_Token": token,
+                    }
+                )
+
+                try:
+                    login_response = await login_session.request(
+                        HTTPMethod.POST,
+                        self.base_url.joinpath("login.cgi"),
+                        data=payload,
+                        headers={
+                            "User-Agent": self.headers["User-Agent"],
+                            "Accept": (
+                                "text/html,application/xhtml+xml,application/xml;"
+                                "q=0.9,*/*;q=0.8"
+                            ),
+                            "Accept-Encoding": "identity",
+                            "Content-Type": "application/x-www-form-urlencoded",
+                            "Origin": origin,
+                            "Referer": f"{origin}/",
+                            "Upgrade-Insecure-Requests": "1",
+                            "Cookie": f"Cookie=body:Language:{language}:id=-1",
+                        },
+                        timeout=DEFAULT_TIMEOUT,
+                        ssl=False,
+                        allow_redirects=False,
+                    )
+                except ClientResponseError as err:
+                    raise CannotConnect from err
+
+                headers = login_response.headers
+                set_cookie_value = ""
+                if hasattr(headers, "getall"):
+                    values = headers.getall("Set-Cookie", []) or headers.getall(
+                        "set-cookie", []
+                    )
+                    set_cookie_value = values[0] if values else ""
+                else:
+                    set_cookie_value = (
+                        headers.get("Set-Cookie")
+                        or headers.get("set-cookie")
+                        or ""
+                    )
+                await login_response.read()
+        finally:
+            await connector.close()
+
+        if not set_cookie_value or "sid=" not in set_cookie_value:
+            raise CannotAuthenticate
+
+        # Keep the raw ``Cookie=sid=...:Language:...:id=1`` header value. The
+        # cookie *name* is literally ``Cookie``, which aiohttp's jar mangles.
+        self._session_cookie = set_cookie_value.split(";", 1)[0]
+        self.session.cookie_jar.clear()
+
+        with contextlib.suppress(GenericResponseError, ClientResponseError, GenericLoginError):
+            await self._refresh_onttoken()
+
+        _LOGGER.debug("Logged into %s", self.base_url.host)
+        return True
+
+    async def _refresh_onttoken(self) -> None:
+        """Load a page that embeds ``onttoken`` and store it as csrf_token."""
+        text = await self._request_text("html/amp/ptvdf/vdfWlanBasicNew.asp")
+        match = _ONTTOKEN_RE.search(text)
+        if not match:
+            # index.asp also carries device info; try overview as fallback later.
+            text = await self._request_text("index.asp")
+            match = _ONTTOKEN_RE.search(text)
+        if match:
+            self.csrf_token = match.group(1) or match.group(2) or ""
+            _LOGGER.debug("onttoken refreshed")
+
+    def _auth_headers(self, *, referer: str | None = None) -> dict[str, str]:
+        """Build request headers including the session cookie."""
+        if not self._session_cookie:
+            raise GenericLoginError("Not authenticated")
+        headers = {
+            **self.headers,
+            "Accept": "*/*",
+            "Accept-Encoding": "identity",
+            "Cookie": self._session_cookie,
+            "Origin": str(self.base_url).rstrip("/"),
+            "Referer": referer
+            or f"{str(self.base_url).rstrip('/')}/index.asp",
+        }
+        return headers
+
+    async def _request_text(
+        self,
+        page: str,
+        *,
+        method: str = HTTPMethod.GET,
+        payload: dict[str, Any] | str | None = None,
+        additional_params: dict[str, Any] | None = None,
+    ) -> str:
+        """Perform an authenticated request and return decoded body text."""
+        timeout = (additional_params or {}).get(REQUEST_TIMEOUT, DEFAULT_TIMEOUT)
+        url = self.base_url.joinpath(page)
+        _LOGGER.debug("%s page %s host %s", method, page, self.base_url.host)
+        try:
+            response = await self.session.request(
+                method,
+                url,
+                data=payload,
+                headers=self._auth_headers(),
+                timeout=timeout,
+                ssl=False,
+                allow_redirects=False,
+            )
+        except ClientResponseError as err:
+            raise GenericResponseError(f"Client response error: {err!s}") from err
+
+        if response.status == HTTPStatus.FORBIDDEN:
+            raise GenericLoginError("Session expired (HTTP 403)")
+        if response.status != HTTPStatus.OK:
+            raise GenericResponseError(
+                f"{method} {page} failed with status {response.status}"
+            )
+        return _decode_js_string(await response.text())
+
+    async def get_devices_data(self) -> dict[str, VodafoneStationDevice]:
+        """Return connected/known LAN devices keyed by MAC address."""
+        _LOGGER.debug("Getting devices host %s", self.base_url.host)
+        text = await self._request_text(
+            "html/bbsp/common/GetLanUserDevInfo.asp",
+            method=HTTPMethod.POST,
+            payload="",
+        )
+        devices: dict[str, VodafoneStationDevice] = {}
+        for args in _parse_ctor_calls(text, "USERDevice"):
+            fields = dict(zip(_USER_DEVICE_FIELDS, args, strict=False))
+            mac = fields.get("MacAddr", "").lower()
+            if not mac or mac in devices:
+                continue
+            port_type = (fields.get("PortType") or "").upper()
+            connection_type = "WiFi" if port_type == "WIFI" else "Ethernet"
+            hostname = (
+                fields.get("HostName")
+                or fields.get("UserDevAlias")
+                or fields.get("IpAddr")
+                or mac
+            )
+            devices[mac] = VodafoneStationDevice(
+                connected=(fields.get("DevStatus") or "").lower() == "online",
+                connection_type=connection_type,
+                ip_address=fields.get("IpAddr") or "",
+                name=hostname,
+                mac=mac,
+                type=fields.get("DevType") or port_type or "",
+                wifi=fields.get("Port") or "",
+            )
+        self._devices = devices
+        return devices
+
+    async def get_sensor_data(self) -> dict[str, Any]:
+        """Collect sensor values expected by the Home Assistant integration."""
+        _LOGGER.debug("Getting sensor data host %s", self.base_url.host)
+        index_text = await self._request_text("index.asp")
+        wan_text = await self._request_text(
+            "html/bbsp/common/getwanlist.asp",
+            method=HTTPMethod.POST,
+            payload="",
+        )
+
+        data: dict[str, Any] = {
+            "sys_serial_number": "",
+            "sys_firmware_version": "",
+            "sys_hardware_version": "",
+            "sys_model_name": self._product_name,
+            "sys_uptime": "",
+            "fw_version": "",
+            "wan_ip4_addr": "",
+            "wan_ip6_addr": "",
+            "inter_ip_address": "",
+            "fiber_ipaddr": "",
+            "fiber_ready": "0",
+            "dsl_ipaddr": "",
+            "dsl_ready": "0",
+            "vf_internet_key_ip_addr": "",
+            "phone_num1": "",
+            "phone_num2": "",
+            "down_str": "",
+            "up_str": "",
+            "sys_cpu_usage": "",
+            "sys_memory_usage": "",
+            "sys_reboot_cause": "",
+            "wan_status": "",
+        }
+
+        product_match = _PRODUCT_NAME_RE.search(index_text)
+        if product_match:
+            data["sys_model_name"] = _decode_js_string(product_match.group(1))
+            self._product_name = data["sys_model_name"]
+
+        device_info = _DEVICE_INFO_RE.search(index_text)
+        if device_info:
+            data["sys_firmware_version"] = device_info.group(2)
+            data["fw_version"] = device_info.group(2)
+            data["sys_uptime"] = device_info.group(3)
+
+        # Serial is not always exposed on user-level pages; use WAN MAC / model.
+        internet_ip = ""
+        wan_uptime = ""
+        for args in (_parse_ctor_args(match.group(1)) for match in _WAN_IP_RE.finditer(wan_text)):
+            if len(args) < 16:
+                continue
+            service = args[8] if len(args) > 8 else ""
+            status = args[12] if len(args) > 12 else args[5]
+            external_ip = args[15]
+            uptime = args[43] if len(args) > 43 else ""
+            if service.lower() == "internet":
+                internet_ip = external_ip
+                wan_uptime = uptime
+                data["wan_status"] = status
+                data["fiber_ipaddr"] = external_ip
+                data["fiber_ready"] = "1" if status.lower() == "connected" else "0"
+                break
+
+        data["wan_ip4_addr"] = internet_ip
+        data["inter_ip_address"] = internet_ip
+        if not data["sys_uptime"] and wan_uptime:
+            data["sys_uptime"] = wan_uptime
+
+        if not data["sys_model_name"] and self._product_name:
+            data["sys_model_name"] = self._product_name
+
+        # User-level UI often hides ONT serial; build a stable unique id.
+        if not data["sys_serial_number"]:
+            parts = [
+                data["sys_model_name"] or self._product_name or "HUAWEI",
+                internet_ip or (self.base_url.host or "ont"),
+            ]
+            data["sys_serial_number"] = "-".join(parts)
+
+        if not data["sys_hardware_version"]:
+            data["sys_hardware_version"] = data["sys_model_name"] or self._product_name
+
+        # Phone numbers (optional page).
+        with contextlib.suppress(GenericResponseError, GenericLoginError):
+            phone_text = await self._request_text(
+                "html/voip/vdfphonenumber/sipphonenumvdf.asp"
+            )
+            numbers = [
+                num
+                for num in (
+                    _decode_js_string(m.group(1))
+                    for m in _LINE_URI_RE.finditer(phone_text)
+                )
+                if num and not num.lower().startswith("line")
+            ]
+            if numbers:
+                data["phone_num1"] = numbers[0]
+            if len(numbers) > 1:
+                data["phone_num2"] = numbers[1]
+
+        # IPv6 WAN address when present.
+        with contextlib.suppress(GenericResponseError, GenericLoginError):
+            ipv6_text = await self._request_text("html/bbsp/common/wanipv6state.asp")
+            for args in _parse_ctor_calls(ipv6_text, "IPv6AddressInfo"):
+                if len(args) >= 4 and args[3] and args[3] != "::":
+                    data["wan_ip6_addr"] = args[3]
+                    break
+
+        self._overview.update(data)
+        return data
+
+    async def get_wifi_data(self) -> dict[str, Any]:
+        """Return Wi-Fi status / credentials for main and guest networks."""
+        _LOGGER.debug("Getting Wi-Fi data host %s", self.base_url.host)
+        overview = await self._request_text("overview.asp")
+        psk_page = await self._request_text("html/amp/ptvdf/getWlanPsw.asp")
+
+        # instance -> (enable, iface, ssid)
+        # overview stWlan(domain, enable, iface, ssid) — args already decoded.
+        ssids: dict[int, tuple[str, str, str]] = {}
+        for args in _parse_ctor_calls(overview, "stWlan"):
+            if len(args) < 4:
+                continue
+            instance = _wlan_instance(args[0])
+            if instance is not None:
+                ssids[instance] = (args[1], args[2], args[3])
+
+        # getWlanPsw uses stWlan(domain, enable, name/iface, BeaconType)
+        beacons: dict[int, str] = {}
+        for args in _parse_ctor_calls(psk_page, "stWlan"):
+            if len(args) < 4:
+                continue
+            instance = _wlan_instance(args[0])
+            if instance is not None:
+                beacons[instance] = args[3]
+                if instance not in ssids:
+                    ssids[instance] = (args[1], args[2], args[2])
+
+        passwords: dict[int, str] = {}
+        for args in _parse_ctor_calls(psk_page, "stPreSharedKey"):
+            if len(args) < 2:
+                continue
+            instance = _wlan_instance(args[0])
+            if instance is not None:
+                passwords[instance] = args[1]
+
+        wifi_data: dict[str, Any] = {WIFI_DATA: {}}
+        for key, instance in (
+            ((WifiType.MAIN, WifiBand.BAND_2_4_GHZ), 1),
+            ((WifiType.GUEST, WifiBand.BAND_2_4_GHZ), 2),
+            ((WifiType.MAIN, WifiBand.BAND_5_GHZ), 5),
+            ((WifiType.GUEST, WifiBand.BAND_5_GHZ), 6),
+        ):
+            entry_key = _WIFI_ENTRY_KEY[key]
+            enable, _iface, ssid = ssids.get(instance, ("0", "", ""))
+            password = passwords.get(instance, "")
+            security = _BEACON_SECURITY.get(beacons.get(instance, ""), "WPA2")
+            entry: dict[str, Any] = {
+                "on": int(enable == "1"),
+                "ssid": ssid,
+                "password": password,
+                "security": security,
+            }
+            if key[0] == WifiType.GUEST and ssid:
+                entry["qr_code"] = await self._generate_guest_qr_code(
+                    ssid, password, security
+                )
+            wifi_data[WIFI_DATA][entry_key] = entry
+
+        return wifi_data
+
+    async def get_docis_data(self) -> dict[str, Any]:
+        """DOCSIS is not applicable to this fiber ONT."""
+        return {}
+
+    async def get_voice_data(self) -> dict[str, Any]:
+        """Return basic voice line data when available."""
+        data: dict[str, Any] = {"line1": {}, "line2": {}, "general": {}}
+        with contextlib.suppress(GenericResponseError, GenericLoginError):
+            phone_text = await self._request_text(
+                "html/voip/vdfphonenumber/sipphonenumvdf.asp"
+            )
+            numbers = [
+                _decode_js_string(m.group(1))
+                for m in _LINE_URI_RE.finditer(phone_text)
+            ]
+            for idx, number in enumerate(numbers[:2], start=1):
+                if number and not number.lower().startswith("line"):
+                    data[f"line{idx}"] = {"call_number": number}
+        return data
+
+    async def set_wifi_status(
+        self,
+        enable: bool,
+        wifi_type: WifiType,
+        band: WifiBand,
+    ) -> None:
+        """Enable or disable a Wi-Fi SSID."""
+        _LOGGER.debug(
+            "Switching %s Wi-Fi (%s) %s on %s",
+            wifi_type,
+            band,
+            enable,
+            self.base_url.host,
+        )
+        instance = _WLAN_INDEX.get((wifi_type, band))
+        if instance is None:
+            raise GenericResponseError(f"Unsupported wifi target {wifi_type}/{band}")
+
+        if not self.csrf_token:
+            await self._refresh_onttoken()
+        if not self.csrf_token:
+            raise GenericLoginError("Missing onttoken for Wi-Fi update")
+
+        domain = f"InternetGatewayDevice.LANDevice.1.WLANConfiguration.{instance}"
+        page = (
+            f"set.cgi?x={domain}"
+            f"&RequestFile=html/amp/ptvdf/vdfWlanBasicNew.asp"
+        )
+        payload = urlencode(
+            {
+                "x.Enable": "1" if enable else "0",
+                "x.X_HW_Token": self.csrf_token,
+            }
+        )
+        await self._request_text(
+            page,
+            method=HTTPMethod.POST,
+            payload=payload,
+        )
+        # Token is single-use on many firmwares.
+        self.csrf_token = ""
+        with contextlib.suppress(GenericResponseError, GenericLoginError):
+            await self._refresh_onttoken()
+
+    async def restart_connection(self, connection_type: str) -> None:
+        """Internet connection restart is not exposed on this firmware."""
+        raise NotImplementedError(
+            f"restart_connection({connection_type}) is not supported on Huawei ONT"
+        )
+
+    async def restart_router(self) -> None:
+        """Reboot the router via DeviceInfo X_HW_Reboot when available."""
+        _LOGGER.debug("Restarting router %s", self.base_url.host)
+        if not self.csrf_token:
+            await self._refresh_onttoken()
+        if not self.csrf_token:
+            raise GenericLoginError("Missing onttoken for reboot")
+
+        # Common Huawei ONT reboot parameter. Some builds ignore unknown fields
+        # without error; callers should treat this as best-effort.
+        page = (
+            "set.cgi?x=InternetGatewayDevice.X_HW_DEBUG.SMP.DM"
+            "&RequestFile=html/ssmp/cfgfile/cfgfileptvdf.asp"
+        )
+        payload = urlencode(
+            {
+                "x.X_HW_Command": "Reboot",
+                "x.X_HW_Token": self.csrf_token,
+            }
+        )
+        with contextlib.suppress(TimeoutError, GenericResponseError):
+            await self._request_text(
+                page,
+                method=HTTPMethod.POST,
+                payload=payload,
+                additional_params={REQUEST_TIMEOUT: POST_RESTART_TIMEOUT},
+            )
+        self.csrf_token = ""
+        self._session_cookie = None
+
+    async def logout(self) -> None:
+        """Log out and clear the local session cookie."""
+        _LOGGER.debug("Logging out router %s", self.base_url.host)
+        if self._session_cookie:
+            with contextlib.suppress(Exception):
+                await self.session.request(
+                    HTTPMethod.GET,
+                    self.base_url.joinpath("logout.cgi"),
+                    headers=self._auth_headers(),
+                    timeout=DEFAULT_TIMEOUT,
+                    ssl=False,
+                    allow_redirects=False,
+                )
+        self._session_cookie = None
+        self.csrf_token = ""
+        self.session.cookie_jar.clear()

--- a/src/aiovodafone/models/huawei.py
+++ b/src/aiovodafone/models/huawei.py
@@ -90,9 +90,17 @@ _ONTTOKEN_RE = re.compile(
     re.I,
 )
 _PRODUCT_NAME_RE = re.compile(r"productName\s*=\s*'((?:\\x[0-9a-fA-F]{2}|[^'])*)'")
+# index.asp: stDeviceInfo(domain, SoftwareVersion, UpTimeStr)
 _DEVICE_INFO_RE = re.compile(
     r'new\s+stDeviceInfo\(\s*"([^"]*)"\s*,\s*"([^"]*)"\s*,\s*"([^"]*)"\s*\)'
 )
+# Status_ptvdf.asp: stDeviceInfo(domain, Serial, HW, SW, Description, UpTimeSeconds)
+_STATUS_DEVICE_INFO_RE = re.compile(
+    r'new\s+stDeviceInfo\(\s*"([^"]*)"\s*,\s*"([^"]*)"\s*,\s*"([^"]*)"\s*,'
+    r'\s*"([^"]*)"\s*,\s*"((?:[^"\\]|\\.)*)"\s*,\s*"([^"]*)"\s*\)'
+)
+_CPU_USED_RE = re.compile(r"var\s+cpuUsed\s*=\s*'([^']*)'")
+_MEM_USED_RE = re.compile(r"var\s+memUsed\s*=\s*'([^']*)'")
 _LINE_URI_RE = re.compile(r'new\s+stLineURI\(\s*"[^"]*"\s*,\s*"([^"]*)"\s*\)')
 _WAN_IP_RE = re.compile(r"new\s+WanIP\((.*?)\)\s*(?:,|;|\))", re.S)
 
@@ -411,7 +419,7 @@ class VodafoneStationHuaweiApi(VodafoneStationCommonApi):
 
     async def get_sensor_data(self) -> dict[str, Any]:
         """Collect sensor values expected by the Home Assistant integration."""
-        _LOGGER.debug("Getting sensor data host %s", self.base_url.host)
+        _LOGGER.debug("Getting sensor data for host %s", self.base_url.host)
         index_text = await self._request_text("index.asp")
         wan_text = await self._request_text(
             "html/bbsp/common/getwanlist.asp",
@@ -419,6 +427,9 @@ class VodafoneStationHuaweiApi(VodafoneStationCommonApi):
             payload="",
         )
 
+        # Only include keys with real values for numeric HA sensors. Empty
+        # strings for data_rate / percentage keys crash entity updates
+        # (ValueError on float("")) and make entities flap unavailable.
         data: dict[str, Any] = {
             "sys_serial_number": "",
             "sys_firmware_version": "",
@@ -436,10 +447,6 @@ class VodafoneStationHuaweiApi(VodafoneStationCommonApi):
             "vf_internet_key_ip_addr": "",
             "phone_num1": "",
             "phone_num2": "",
-            "down_str": "",
-            "up_str": "",
-            "sys_cpu_usage": "",
-            "sys_memory_usage": "",
             "sys_reboot_cause": "",
             "wan_status": "",
         }
@@ -455,10 +462,45 @@ class VodafoneStationHuaweiApi(VodafoneStationCommonApi):
             data["fw_version"] = device_info.group(2)
             data["sys_uptime"] = device_info.group(3)
 
+        # Status page: CPU/memory + full DeviceInfo (serial, HW, SW, uptime secs).
+        with contextlib.suppress(GenericResponseError, GenericLoginError):
+            status_text = await self._request_text(
+                "html/bbsp/status/Status_ptvdf.asp"
+            )
+            if cpu_match := _CPU_USED_RE.search(status_text):
+                cpu = cpu_match.group(1).strip()
+                if cpu.endswith("%") and cpu[:-1].strip():
+                    data["sys_cpu_usage"] = cpu
+            if mem_match := _MEM_USED_RE.search(status_text):
+                mem = mem_match.group(1).strip()
+                if mem.endswith("%") and mem[:-1].strip():
+                    data["sys_memory_usage"] = mem
+            if status_info := _STATUS_DEVICE_INFO_RE.search(status_text):
+                serial = _decode_js_string(status_info.group(2)).strip()
+                hardware = _decode_js_string(status_info.group(3)).strip()
+                software = _decode_js_string(status_info.group(4)).strip()
+                description = _decode_js_string(status_info.group(5)).strip()
+                uptime_secs = status_info.group(6).strip()
+                if serial:
+                    data["sys_serial_number"] = serial
+                if hardware:
+                    data["sys_hardware_version"] = hardware
+                if software:
+                    data["sys_firmware_version"] = software
+                    data["fw_version"] = software
+                if uptime_secs.isdigit():
+                    data["sys_uptime"] = uptime_secs
+                # Prefer short model from productName; fall back to description.
+                if not data["sys_model_name"] and description:
+                    data["sys_model_name"] = description.split("(")[0].strip()
+
         # Serial is not always exposed on user-level pages; use WAN MAC / model.
         internet_ip = ""
         wan_uptime = ""
-        for args in (_parse_ctor_args(match.group(1)) for match in _WAN_IP_RE.finditer(wan_text)):
+        for args in (
+            _parse_ctor_args(match.group(1))
+            for match in _WAN_IP_RE.finditer(wan_text)
+        ):
             if len(args) < 16:
                 continue
             service = args[8] if len(args) > 8 else ""
@@ -470,7 +512,9 @@ class VodafoneStationHuaweiApi(VodafoneStationCommonApi):
                 wan_uptime = uptime
                 data["wan_status"] = status
                 data["fiber_ipaddr"] = external_ip
-                data["fiber_ready"] = "1" if status.lower() == "connected" else "0"
+                data["fiber_ready"] = (
+                    "1" if status.lower() == "connected" else "0"
+                )
                 break
 
         data["wan_ip4_addr"] = internet_ip
@@ -490,7 +534,9 @@ class VodafoneStationHuaweiApi(VodafoneStationCommonApi):
             data["sys_serial_number"] = "-".join(parts)
 
         if not data["sys_hardware_version"]:
-            data["sys_hardware_version"] = data["sys_model_name"] or self._product_name
+            data["sys_hardware_version"] = (
+                data["sys_model_name"] or self._product_name
+            )
 
         # Phone numbers (optional page).
         with contextlib.suppress(GenericResponseError, GenericLoginError):
@@ -512,7 +558,9 @@ class VodafoneStationHuaweiApi(VodafoneStationCommonApi):
 
         # IPv6 WAN address when present.
         with contextlib.suppress(GenericResponseError, GenericLoginError):
-            ipv6_text = await self._request_text("html/bbsp/common/wanipv6state.asp")
+            ipv6_text = await self._request_text(
+                "html/bbsp/common/wanipv6state.asp"
+            )
             for args in _parse_ctor_calls(ipv6_text, "IPv6AddressInfo"):
                 if len(args) >= 4 and args[3] and args[3] != "::":
                     data["wan_ip6_addr"] = args[3]

--- a/src/aiovodafone/models/huawei.py
+++ b/src/aiovodafone/models/huawei.py
@@ -13,7 +13,7 @@ from typing import Any
 from urllib.parse import urlencode
 
 import aiohttp
-from aiohttp import ClientResponseError, ClientSession
+from aiohttp import ClientError, ClientResponseError, ClientSession
 from yarl import URL
 
 from aiovodafone.api import VodafoneStationCommonApi, VodafoneStationDevice
@@ -101,6 +101,10 @@ _STATUS_DEVICE_INFO_RE = re.compile(
 )
 _CPU_USED_RE = re.compile(r"var\s+cpuUsed\s*=\s*'([^']*)'")
 _MEM_USED_RE = re.compile(r"var\s+memUsed\s*=\s*'([^']*)'")
+# Status_ptvdf.asp: stMainDhcpInfo(domain, DHCPServerEnable, MACAddress)
+_MAIN_DHCP_MAC_RE = re.compile(
+    r'new\s+stMainDhcpInfo\(\s*"[^"]*"\s*,\s*"[^"]*"\s*,\s*"([^"]*)"\s*\)'
+)
 _LINE_URI_RE = re.compile(r'new\s+stLineURI\(\s*"[^"]*"\s*,\s*"([^"]*)"\s*\)')
 _WAN_IP_RE = re.compile(r"new\s+WanIP\((.*?)\)\s*(?:,|;|\))", re.S)
 
@@ -207,7 +211,7 @@ class VodafoneStationHuaweiApi(VodafoneStationCommonApi):
                 connector=connector, cookie_jar=aiohttp.DummyCookieJar()
             ) as login_session:
                 # Login page exposes productName used as model.
-                with contextlib.suppress(ClientResponseError, TimeoutError, AttributeError):
+                with contextlib.suppress(TimeoutError, ClientError):
                     login_page = await login_session.request(
                         HTTPMethod.GET,
                         self.base_url.joinpath(""),
@@ -246,7 +250,7 @@ class VodafoneStationHuaweiApi(VodafoneStationCommonApi):
                         ssl=False,
                         allow_redirects=False,
                     )
-                except ClientResponseError as err:
+                except (TimeoutError, ClientError) as err:
                     raise CannotConnect from err
 
                 if token_response.status != HTTPStatus.OK:
@@ -289,7 +293,7 @@ class VodafoneStationHuaweiApi(VodafoneStationCommonApi):
                         ssl=False,
                         allow_redirects=False,
                     )
-                except ClientResponseError as err:
+                except (TimeoutError, ClientError) as err:
                     raise CannotConnect from err
 
                 headers = login_response.headers
@@ -356,14 +360,17 @@ class VodafoneStationHuaweiApi(VodafoneStationCommonApi):
         *,
         method: str = HTTPMethod.GET,
         payload: dict[str, Any] | str | None = None,
+        params: dict[str, str] | None = None,
         additional_params: dict[str, Any] | None = None,
     ) -> str:
         """Perform an authenticated request and return decoded body text."""
         timeout = (additional_params or {}).get(REQUEST_TIMEOUT, DEFAULT_TIMEOUT)
         url = self.base_url.joinpath(page)
-        _LOGGER.debug("%s page %s host %s", method, page, self.base_url.host)
+        if params:
+            url = url.with_query(params)
+        _LOGGER.debug("%s page %s for host %s", method, page, self.base_url.host)
         try:
-            response = await self.session.request(
+            async with self.session.request(
                 method,
                 url,
                 data=payload,
@@ -371,17 +378,18 @@ class VodafoneStationHuaweiApi(VodafoneStationCommonApi):
                 timeout=timeout,
                 ssl=False,
                 allow_redirects=False,
-            )
-        except ClientResponseError as err:
+            ) as response:
+                if response.status == HTTPStatus.FORBIDDEN:
+                    raise GenericLoginError("Session expired (HTTP 403)")
+                if response.status != HTTPStatus.OK:
+                    raise GenericResponseError(
+                        f"{method} {page} failed with status {response.status}"
+                    )
+                return _decode_js_string(await response.text())
+        except (GenericLoginError, GenericResponseError):
+            raise
+        except (TimeoutError, ClientError) as err:
             raise GenericResponseError(f"Client response error: {err!s}") from err
-
-        if response.status == HTTPStatus.FORBIDDEN:
-            raise GenericLoginError("Session expired (HTTP 403)")
-        if response.status != HTTPStatus.OK:
-            raise GenericResponseError(
-                f"{method} {page} failed with status {response.status}"
-            )
-        return _decode_js_string(await response.text())
 
     async def get_devices_data(self) -> dict[str, VodafoneStationDevice]:
         """Return connected/known LAN devices keyed by MAC address."""
@@ -494,7 +502,12 @@ class VodafoneStationHuaweiApi(VodafoneStationCommonApi):
                 if not data["sys_model_name"] and description:
                     data["sys_model_name"] = description.split("(")[0].strip()
 
-        # Serial is not always exposed on user-level pages; use WAN MAC / model.
+            if dhcp_mac := _MAIN_DHCP_MAC_RE.search(status_text):
+                lan_mac = dhcp_mac.group(1).strip().lower()
+                if lan_mac.count(":") == 5:
+                    data["_lan_mac"] = lan_mac
+
+        # WAN addressing from getwanlist.asp.
         internet_ip = ""
         wan_uptime = ""
         for args in (
@@ -503,8 +516,8 @@ class VodafoneStationHuaweiApi(VodafoneStationCommonApi):
         ):
             if len(args) < 16:
                 continue
-            service = args[8] if len(args) > 8 else ""
-            status = args[12] if len(args) > 12 else args[5]
+            service = args[8]
+            status = args[12]
             external_ip = args[15]
             uptime = args[43] if len(args) > 43 else ""
             if service.lower() == "internet":
@@ -525,13 +538,13 @@ class VodafoneStationHuaweiApi(VodafoneStationCommonApi):
         if not data["sys_model_name"] and self._product_name:
             data["sys_model_name"] = self._product_name
 
-        # User-level UI often hides ONT serial; build a stable unique id.
+        # Prefer real ONT serial; else stable LAN MAC / host (never dynamic WAN IP).
         if not data["sys_serial_number"]:
-            parts = [
-                data["sys_model_name"] or self._product_name or "HUAWEI",
-                internet_ip or (self.base_url.host or "ont"),
-            ]
-            data["sys_serial_number"] = "-".join(parts)
+            stable = data.pop("_lan_mac", None) or self.base_url.host or "ont"
+            model = data["sys_model_name"] or self._product_name or "HUAWEI"
+            data["sys_serial_number"] = f"{model}-{stable}"
+        else:
+            data.pop("_lan_mac", None)
 
         if not data["sys_hardware_version"]:
             data["sys_hardware_version"] = (
@@ -673,10 +686,6 @@ class VodafoneStationHuaweiApi(VodafoneStationCommonApi):
             raise GenericLoginError("Missing onttoken for Wi-Fi update")
 
         domain = f"InternetGatewayDevice.LANDevice.1.WLANConfiguration.{instance}"
-        page = (
-            f"set.cgi?x={domain}"
-            f"&RequestFile=html/amp/ptvdf/vdfWlanBasicNew.asp"
-        )
         payload = urlencode(
             {
                 "x.Enable": "1" if enable else "0",
@@ -684,9 +693,13 @@ class VodafoneStationHuaweiApi(VodafoneStationCommonApi):
             }
         )
         await self._request_text(
-            page,
+            "set.cgi",
             method=HTTPMethod.POST,
             payload=payload,
+            params={
+                "x": domain,
+                "RequestFile": "html/amp/ptvdf/vdfWlanBasicNew.asp",
+            },
         )
         # Token is single-use on many firmwares.
         self.csrf_token = ""
@@ -709,10 +722,6 @@ class VodafoneStationHuaweiApi(VodafoneStationCommonApi):
 
         # Common Huawei ONT reboot parameter. Some builds ignore unknown fields
         # without error; callers should treat this as best-effort.
-        page = (
-            "set.cgi?x=InternetGatewayDevice.X_HW_DEBUG.SMP.DM"
-            "&RequestFile=html/ssmp/cfgfile/cfgfileptvdf.asp"
-        )
         payload = urlencode(
             {
                 "x.X_HW_Command": "Reboot",
@@ -721,9 +730,13 @@ class VodafoneStationHuaweiApi(VodafoneStationCommonApi):
         )
         with contextlib.suppress(TimeoutError, GenericResponseError):
             await self._request_text(
-                page,
+                "set.cgi",
                 method=HTTPMethod.POST,
                 payload=payload,
+                params={
+                    "x": "InternetGatewayDevice.X_HW_DEBUG.SMP.DM",
+                    "RequestFile": "html/ssmp/cfgfile/cfgfileptvdf.asp",
+                },
                 additional_params={REQUEST_TIMEOUT: POST_RESTART_TIMEOUT},
             )
         self.csrf_token = ""
@@ -731,17 +744,18 @@ class VodafoneStationHuaweiApi(VodafoneStationCommonApi):
 
     async def logout(self) -> None:
         """Log out and clear the local session cookie."""
-        _LOGGER.debug("Logging out router %s", self.base_url.host)
+        _LOGGER.debug("Logging out from router %s", self.base_url.host)
         if self._session_cookie:
-            with contextlib.suppress(Exception):
-                await self.session.request(
+            with contextlib.suppress(TimeoutError, ClientError, GenericLoginError):
+                async with self.session.request(
                     HTTPMethod.GET,
                     self.base_url.joinpath("logout.cgi"),
                     headers=self._auth_headers(),
                     timeout=DEFAULT_TIMEOUT,
                     ssl=False,
                     allow_redirects=False,
-                )
+                ):
+                    pass
         self._session_cookie = None
         self.csrf_token = ""
         self.session.cookie_jar.clear()

--- a/tests/fixtures/huawei/GetLanUserDevInfo.asp
+++ b/tests/fixtures/huawei/GetLanUserDevInfo.asp
@@ -1,0 +1,159 @@
+﻿function USERDevice(Domain,IpAddr,MacAddr,Port,IpType,DevType,DevStatus,PortType,Time,HostName,IPv4Enabled,IPv6Enabled,DeviceType,UserDevAlias,UserSpecifiedDeviceType,LeaseTimeRemaining,RealMacAddr)
+{
+	this.Domain 	= Domain;
+	this.IpAddr	    = (IpAddr.length == 0)?"--":IpAddr;
+	this.MacAddr	= MacAddr;
+
+	if(Port=="LAN0" || Port=="SSID0")
+	{
+		this.Port  = "--"; 
+	}
+	else
+	{
+		this.Port  = Port;
+	}
+	
+	this.PortID = Port; 
+	
+	this.PortType	= PortType;
+	
+	this.DevStatus 	= DevStatus;
+	this.IpType		= IpType;
+	if(IpType=="Static")
+	{
+	  this.DevType="--";
+	}
+	else
+	{
+		if(DevType=="")
+		{
+			this.DevType	= "--";	
+		}
+		else
+		{
+			this.DevType	= DevType;		
+		}	
+	}
+	this.Time	    = Time;
+	
+	if(HostName=="")
+	{
+		this.HostName	= "--";
+	}
+	else
+	{
+	   this.HostName	= HostName;
+	}
+	
+	this.IPv4Enabled = IPv4Enabled;
+	this.IPv6Enabled = IPv6Enabled;
+	this.DeviceType = DeviceType;
+	if (UserDevAlias == "")
+	{
+		this.UserDevAlias = "--";
+	}
+	else
+	{
+		this.UserDevAlias = UserDevAlias;
+	}
+	this.UserSpecifiedDeviceType = UserSpecifiedDeviceType;
+	this.LeaseTimeRemaining = LeaseTimeRemaining;
+	this.instid       = '';
+	this.IsClickDev   = false;
+
+    if (isRealmac == 1) {
+        this.RealMacAddr = RealMacAddr;
+    }
+}
+
+var ProductType = '1';
+var isRealmac = '0';
+if (ProductType == '2') {
+    var UserDevinfo = new Array(new USERDevice("InternetGatewayDevice.LANDevice.1.X_HW_UserDev.1","192\x2e168\x2e1\x2e11","02\x3a00\x3a00\x3a00\x3a00\x3a01","LAN1","Static","\x2d\x2d","Online","ETH","0\x3a14","","1","0","0","","0","0"),new USERDevice("InternetGatewayDevice.LANDevice.1.X_HW_UserDev.2","192\x2e168\x2e1\x2e37","02\x3a00\x3a00\x3a00\x3a00\x3a02","SSID1","Static","\x2d\x2d","Offline","WIFI","28\x3a4","","1","0","0","","0","0"),new USERDevice("InternetGatewayDevice.LANDevice.1.X_HW_UserDev.3","192\x2e168\x2e1\x2e1","02\x3a00\x3a00\x3a00\x3a00\x3a03","LAN1","Static","\x2d\x2d","Online","ETH","4\x3a52","","1","0","0","","0","0"),new USERDevice("InternetGatewayDevice.LANDevice.1.X_HW_UserDev.4","192\x2e168\x2e1\x2e31","02\x3a00\x3a00\x3a00\x3a00\x3a04","LAN1","Static","\x2d\x2d","Offline","ETH","0\x3a6","","1","0","0","","0","0"),new USERDevice("InternetGatewayDevice.LANDevice.1.X_HW_UserDev.5","0\x2e0\x2e0\x2e0","02\x3a00\x3a00\x3a00\x3a00\x3a05","SSID1","DHCP","","Offline","WIFI","29\x3a14","","0","1","0","","0","0"),new USERDevice("InternetGatewayDevice.LANDevice.1.X_HW_UserDev.6","192\x2e168\x2e1\x2e84","02\x3a00\x3a00\x3a00\x3a00\x3a06","LAN1","Static","\x2d\x2d","Offline","ETH","0\x3a6","","1","0","0","","0","0"),null);
+} else {
+    var UserDevinfo = new Array(new USERDevice("InternetGatewayDevice.LANDevice.1.X_HW_UserDev.1","192\x2e168\x2e1\x2e11","02\x3a00\x3a00\x3a00\x3a00\x3a01","LAN1","Static","\x2d\x2d","Online","ETH","0\x3a14","","1","0","0","","0","0","02\x3a00\x3a00\x3a00\x3a00\x3a01"),new USERDevice("InternetGatewayDevice.LANDevice.1.X_HW_UserDev.2","192\x2e168\x2e1\x2e37","02\x3a00\x3a00\x3a00\x3a00\x3a02","SSID1","Static","\x2d\x2d","Offline","WIFI","28\x3a4","","1","0","0","","0","0","02\x3a00\x3a00\x3a00\x3a00\x3a02"),new USERDevice("InternetGatewayDevice.LANDevice.1.X_HW_UserDev.3","192\x2e168\x2e1\x2e1","02\x3a00\x3a00\x3a00\x3a00\x3a03","LAN1","Static","\x2d\x2d","Online","ETH","4\x3a52","","1","0","0","","0","0","02\x3a00\x3a00\x3a00\x3a00\x3a03"),new USERDevice("InternetGatewayDevice.LANDevice.1.X_HW_UserDev.4","192\x2e168\x2e1\x2e31","02\x3a00\x3a00\x3a00\x3a00\x3a04","LAN1","Static","\x2d\x2d","Offline","ETH","0\x3a6","","1","0","0","","0","0","02\x3a00\x3a00\x3a00\x3a00\x3a04"),new USERDevice("InternetGatewayDevice.LANDevice.1.X_HW_UserDev.5","0\x2e0\x2e0\x2e0","02\x3a00\x3a00\x3a00\x3a00\x3a05","SSID1","DHCP","","Offline","WIFI","29\x3a14","","0","1","0","","0","0","02\x3a00\x3a00\x3a00\x3a00\x3a05"),new USERDevice("InternetGatewayDevice.LANDevice.1.X_HW_UserDev.6","192\x2e168\x2e1\x2e84","02\x3a00\x3a00\x3a00\x3a00\x3a06","LAN1","Static","\x2d\x2d","Offline","ETH","0\x3a6","","1","0","0","","0","0","02\x3a00\x3a00\x3a00\x3a00\x3a06"),null);
+}
+
+function stWifiWorkingMode(domain,WifiMode,IPAddress,MacAddress)
+{
+	this.domain 		= domain;
+	this.WifiMode 		= WifiMode;
+	this.IPAddress		= IPAddress;
+	this.MacAddress     = MacAddress;
+}
+
+var WifiWorkingModes = new Array(new stWifiWorkingMode("InternetGatewayDevice.LANDevice.1.WLANConfiguration.1.AssociatedDevice.1","11n","","02\x3a00\x3a00\x3a00\x3a00\x3a07"),new stWifiWorkingMode("InternetGatewayDevice.LANDevice.1.WLANConfiguration.1.AssociatedDevice.2","11n","","02\x3a00\x3a00\x3a00\x3a00\x3a08"),new stWifiWorkingMode("InternetGatewayDevice.LANDevice.1.WLANConfiguration.1.AssociatedDevice.3","11n","","02\x3a00\x3a00\x3a00\x3a00\x3a09"),new stWifiWorkingMode("InternetGatewayDevice.LANDevice.1.WLANConfiguration.1.AssociatedDevice.4","11n","0\x2e0\x2e0\x2e0","02\x3a00\x3a00\x3a00\x3a00\x3a05"),new stWifiWorkingMode("InternetGatewayDevice.LANDevice.1.WLANConfiguration.5.AssociatedDevice.1","11ax","","02\x3a00\x3a00\x3a00\x3a00\x3a0a"),new stWifiWorkingMode("InternetGatewayDevice.LANDevice.1.WLANConfiguration.5.AssociatedDevice.2","11ax","","02\x3a00\x3a00\x3a00\x3a00\x3a0b"),new stWifiWorkingMode("InternetGatewayDevice.LANDevice.1.WLANConfiguration.5.AssociatedDevice.3","11ax","","02\x3a00\x3a00\x3a00\x3a00\x3a0c"),new stWifiWorkingMode("InternetGatewayDevice.LANDevice.1.WLANConfiguration.5.AssociatedDevice.4","11na","","02\x3a00\x3a00\x3a00\x3a00\x3a0d"),null);
+var curCfgModeWord ='PTVDF2WIFI_PWD'; 
+var ttnet = '0';
+if (curCfgModeWord == "TALKTALK2WIFI")
+{
+	for(var i = 0; i < UserDevinfo.length - 1; i++)
+	{	var MACmacthFlag = 0; 
+		if (UserDevinfo[i].DevStatus.toUpperCase() == "OFFLINE")
+		{
+			UserDevinfo[i].Port = "--";
+			continue;
+		}
+		
+		if(UserDevinfo[i].PortType != "WIFI")
+		{		
+			UserDevinfo[i].Port = "Ethernet";
+			continue;
+		}
+		
+		
+		for(var j = 0;j < WifiWorkingModes.length - 1 ; j++)
+		{ 
+			if (UserDevinfo[i].MacAddr.toString().toUpperCase() ==  WifiWorkingModes[j].MacAddress.toString().toUpperCase())
+			{	
+				UserDevinfo[i].Port = WifiWorkingModes[j].WifiMode;	
+				MACmacthFlag = 1;
+				break;
+			}	
+		}
+		
+		if(MACmacthFlag != 1)
+		{
+			for(var k = 0;k < WifiWorkingModes.length - 1 ; k++)
+			{
+				if	(UserDevinfo[i].IpAddr.toString() == WifiWorkingModes[k].IPAddress.toString())
+				{
+					UserDevinfo[i].Port = WifiWorkingModes[k].WifiMode;	
+					MACmacthFlag = 1;
+					break;
+				}
+			}
+		}
+		if(MACmacthFlag != 1)
+		{
+			UserDevinfo[i].Port = "--";
+		}
+	}	
+}
+
+
+
+var UserDevinfoTmp = new Array();
+for(var i = 0; i < UserDevinfo.length - 1; i++)
+{
+	var id = UserDevinfo[i].Domain.split(".");
+	UserDevinfo[i].instid = id[id.length -1];
+
+	if (UserDevinfo[i].IPv4Enabled == "1") {
+		if (ttnet == '1') {
+			if (UserDevinfo[i].DevStatus.toUpperCase() == "ONLINE") {
+				UserDevinfoTmp.push(UserDevinfo[i]);
+			}
+		} else {
+			UserDevinfoTmp.push(UserDevinfo[i]);
+		}
+	}
+}
+UserDevinfoTmp.push(null);
+
+function GetUserDevInfoList()
+{
+	return UserDevinfoTmp;
+}
+
+GetUserDevInfoList();

--- a/tests/fixtures/huawei/Status_ptvdf.asp
+++ b/tests/fixtures/huawei/Status_ptvdf.asp
@@ -1,0 +1,360 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html  id="Page" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<meta http-equiv="Pragma" content="no-cache" >
+<meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+<link rel="stylesheet"  href='../../../Cuscss/frame.css?03fa5651e1972f71553184798' type='text/css'>
+<script language="JavaScript" src="../../../resource/common/jquery.min.js?03fa5651e1972f71553184798"></script>
+<script language="JavaScript" src="../../../Cusjs/ptvdfjs.js?03fa5651e1972f71553184798"></script>
+<script language="JavaScript" src="../../../resource/english/bbspdes.html?03fa5651e1972f71553184798"></script>
+<script language="javascript" src="../common/wanipv6state.asp"></script>
+<script language="javascript" src="../common/wan_list_ptvdf.asp?176935"></script>
+<script language="JavaScript" src="../../../resource/english/ampdes.html?03fa5651e1972f71553184798"></script>
+<script>
+
+var wanInfoAll = GetWanList();
+var curIPv4Address = "--";
+var curWanMacId = ""
+var ChanInfo = '7,104';
+WlanChannel2g = ChanInfo.split(',')[0];
+WlanChannel5g = ChanInfo.split(',')[1];
+var language = 'english';
+var typeWord = 'TR181';
+var multiLinkFT = '1' == '1';
+var hideMultiLink = '0' == '1';
+var isSupportMlo = (multiLinkFT && !hideMultiLink);
+
+function GetLanguage(name) {
+    return status_language[name]
+}
+
+for (var i = 0; i < wanInfoAll.length; i++) {
+    if ((wanInfoAll[i].ServiceList.toUpperCase().indexOf("INTERNET") >= 0) && (wanInfoAll[i].Status.toUpperCase() == "UP")) {
+        curWanMacId = wanInfoAll[i].MacId;
+        curIPv4Address = wanInfoAll[i].IPAddress;
+        break;
+    }
+}
+
+var curIPv6Address = "--";
+var curIPv6Prefix = "--";
+if (curWanMacId != "") {
+    var curIPv6AddressList = GetIPv6AddressList(curWanMacId);
+    var curIPv6PrefixList = GetIPv6PrefixList(curWanMacId);
+    if (curIPv6AddressList.length != 0) {
+        curIPv6Address = curIPv6AddressList[0].IPAddress;
+    }
+    if (curIPv6PrefixList.length != 0) {
+        curIPv6Prefix = curIPv6PrefixList[0].Prefix;
+    }
+}
+
+function stLanHostInfo(domain, IPInterfaceIPAddress, IPInterfaceSubnetMask) {
+    this.domain = domain;
+    this.IPAddress = IPInterfaceIPAddress;
+    this.SubnetMask = IPInterfaceSubnetMask;
+}
+
+function stMainDhcpInfo(domain, DHCPServerEnable, MACAddress) {
+    this.domain = domain;
+    this.DHCPServerEnable = DHCPServerEnable;
+    this.MACAddress = MACAddress;
+}
+function IPAddressAcquireIPItem(_domain, _DefaultGateway) {
+    this.domain = _domain;
+    this.DefaultGateway = _DefaultGateway;
+}
+
+function IPAddressAcquirePPPItem(_domain, _DefaultGateway) {
+    this.domain = _domain;
+    this.DefaultGateway = _DefaultGateway;
+}
+
+var IPAddressAcquireIP  = new Array(new IPAddressAcquireIPItem("InternetGatewayDevice.WANDevice.1.WANConnectionDevice.1.WANIPConnection.1.X_HW_IPv6.IPv6Address.1",""),null);
+var IPAddressAcquirePPP = new Array(null);
+var IPAddressAcquireList = truncate(IPAddressAcquireIP).concat(truncate(IPAddressAcquirePPP));
+var lanHostInfos = new Array(new stLanHostInfo("InternetGatewayDevice.LANDevice.1.LANHostConfigManagement.IPInterface.1","192.0.2.2","255.255.255.0"),null);
+var lanHostInfo = lanHostInfos[0];
+var mainDhcpInfos = new Array(new stMainDhcpInfo("InternetGatewayDevice.LANDevice.1.LANHostConfigManagement","0","00:11:22:33:44:01"),null);
+var mainDhcpInfo = mainDhcpInfos[0];
+var dhcpv6ServerEnable = '1'
+var dhcpv6RouteEnable = '1'
+
+var cpuUsed = '24%';
+var memUsed = '12%';
+var systemdsttime = '2026-08-09 12:25:11+00:00 DST';
+
+function stDeviceInfo(domain,SerialNumber,HardwareVersion,SoftwareVersion,Description,UpTime)
+{
+    this.domain                = domain;
+    this.SerialNumber          = SerialNumber;
+    this.HardwareVersion       = HardwareVersion;
+    this.SoftwareVersion       = SoftwareVersion;
+    this.Description           = Description;
+    this.UpTime                = UpTime;
+}
+
+function CreatStatusInfoTable(tableTitle, tableID, tableArrayInfo, tablewidth) {
+    var htmlinfo = '<div id="' + tableID + '" style="margin-bottom:50px;">';
+    if (tableTitle != "" && tableTitle != null) {
+        htmlinfo += '<h3><span class="language-string">' + tableTitle + '</span></h3>';
+    }
+    htmlinfo += '<div class="h3-wrapper-content no-padding-bottom">';
+    htmlinfo += '<div class="table desktop" style="font-size: 13px;text-align: center;">';
+    for (var m = 0; m < tableArrayInfo.length; m++) {
+        var lastclass = (m == tableArrayInfo.length - 1) ? "table-row" : "table-row bottomline";
+        htmlinfo += '<div class="' + lastclass + '">';
+        for (var n = 0; n < tableArrayInfo[m].length; n++) {
+            if ((typeof tablewidth == "undefined") || (tablewidth == "") || (tablewidth == null)) {
+                htmlinfo += '<div class="table-col-status" style="width:' + (100/tableArrayInfo[0].length) + '%;">' + changetospace(escapeHTML(tableArrayInfo[m][n])) + '</div>';
+            } else {
+                htmlinfo += '<div class="table-col-status" style="width:' + tablewidth[n] + '%;">' + changetospace(escapeHTML(tableArrayInfo[m][n])) + '</div>';
+            }
+        }
+        htmlinfo +='</div>';
+    }
+    htmlinfo +='</div>';
+    htmlinfo +='</div>';
+    htmlinfo +='</div>';
+    document.write(htmlinfo);
+}
+
+function LanPortStatus(domain,Status,Speed)
+{
+    this.domain	= domain;
+    this.Status = Status; 
+    this.Speed 	= Speed; 
+
+    if(Status=='Up')
+    {
+        if(Speed=='Auto_10')this.Speed = 10;
+        if(Speed=='Auto_100')this.Speed = 100;
+        if(Speed=='Auto_1000')this.Speed = 1000;
+        if(Speed=='Auto_2500')this.Speed = 2500;
+        this.Status = status_LANnetwork_language['amp_lan_port_on'];
+    }
+    else
+    {
+        this.Speed = 0;
+        this.Status = status_LANnetwork_language['amp_lan_port_off'];
+    }
+    
+}
+function getSameIPandMask(ipAddress, subnetMask) {
+    var maskStr ="";
+    var IPStrArr = [];
+    var tmpMask = subnetMask.split('.');
+    var tmpIp = ipAddress.split('.');
+    for (var maskLenNum = 0; maskLenNum < 4; maskLenNum++) {
+        tmpNum0 = parseInt(tmpIp[maskLenNum]);
+        tmpNum1 = parseInt(tmpMask[maskLenNum]);
+        tmpNum2 = tmpNum0 & tmpNum1;
+        IPStrArr.push(tmpNum2)
+    }
+    for (let i = 0; i < tmpMask.length; i++) {
+        if (tmpMask[i] != "0") {
+            maskStr += parseInt(tmpMask[i]).toString(2)
+        } else {
+            continue;
+        }
+    }
+    return IPStrArr.join(".") + "/" + maskStr.length;
+}
+var LanPortStatuss = new Array(new LanPortStatus("InternetGatewayDevice.LANDevice.1.LANEthernetInterfaceConfig.1","Up","Auto_1000"),new LanPortStatus("InternetGatewayDevice.LANDevice.1.LANEthernetInterfaceConfig.2","Down","Auto_10"),new LanPortStatus("InternetGatewayDevice.LANDevice.1.LANEthernetInterfaceConfig.3","Down","Auto_10"),new LanPortStatus("InternetGatewayDevice.LANDevice.1.LANEthernetInterfaceConfig.4","Down","Auto_10"),null);
+var deviceInfos = new Array(new stDeviceInfo("InternetGatewayDevice.DeviceInfo","TESTSERIAL00000001","3F80.A","V5R024C00S114","OptiXstar HG8247B7-8N GPON Terminal (CLASS B+/PRODUCT ID:0000000000000000000EGR0000000)","176935"),null);
+var wantableArr = new Array();
+wantableArr.push([GetLanguage("status006"), curIPv4Address, ""]);
+wantableArr.push([GetLanguage("status007"), curIPv6Address, ""]);
+wantableArr.push([GetLanguage("status008"), curIPv6Prefix, ""]);
+
+var lantableArr = new Array();
+
+lantableArr.push([GetLanguage("status009"), getSameIPandMask(lanHostInfo.IPAddress, lanHostInfo.SubnetMask), ""]);
+lantableArr.push([GetLanguage("status010"), lanHostInfo.IPAddress, ""]);
+lantableArr.push([GetLanguage("status012"), mainDhcpInfo.MACAddress, ""]);
+if (typeWord != "BR") {
+    lantableArr.push([GetLanguage("status013"), getStatus(mainDhcpInfo.DHCPServerEnable), ""]);
+    lantableArr.push([GetLanguage("status014"), getStatus(dhcpv6ServerEnable), ""]);
+    lantableArr.push([GetLanguage("status015"), getStatus(dhcpv6RouteEnable), ""]);
+
+    var ipv6Wan = GetIPv6WanInfo(curWanMacId)
+    if ((ipv6Wan == null) || (ipv6Wan == "")) {
+        lantableArr.push([GetLanguage("status016"), "--", ""]);
+    } else {
+        lantableArr.push([GetLanguage("status016"), ipv6Wan.DefaultRouterAddress, ""]);
+    }
+}
+
+var lanid;
+for(var i = 0; i < LanPortStatuss.length - 1; i++)
+{
+    lanid = i + 1;
+    lantableArr.push([GetLanguage("status030") + lanid, LanPortStatuss[i].Status, LanPortStatuss[i].Speed + ' Mbps']);
+}
+
+var WlanInfo = new Array();
+WlanInfo = new Array(new stWlan("InternetGatewayDevice.LANDevice.1.WLANConfiguration.1","1","ath0","Vodafone-21AF54","11i","7","00:11:22:33:44:02","Up"),new stWlan("InternetGatewayDevice.LANDevice.1.WLANConfiguration.2","0","ath1","Vodafone-21AF54-Guest","11i","7","00:11:22:33:44:03","Down"),new stWlan("InternetGatewayDevice.LANDevice.1.WLANConfiguration.3","0","ath2","Vodafone-21AF54_WiFi7","WPA3","7","00:11:22:33:44:04","Down"),new stWlan("InternetGatewayDevice.LANDevice.1.WLANConfiguration.4","0","ath6","Vodafone-21AF54_WiFi7","WPA3","104","00:11:22:33:44:05","Down"),new stWlan("InternetGatewayDevice.LANDevice.1.WLANConfiguration.5","1","ath4","Vodafone-21AF54","11i","104","00:11:22:33:44:06","Up"),new stWlan("InternetGatewayDevice.LANDevice.1.WLANConfiguration.6","0","ath5","Vodafone-21AF54-Guest","11i","104","00:11:22:33:44:07","Down"),null);  
+for (var i = 0; i <  WlanInfo.length; i++) {
+    if (WlanInfo[i] == null) {
+        WlanInfo.splice(i,1);
+    }
+}
+var wifi2G = new Array();
+var wifi5G = new Array();
+var wifi7for2G = {};
+var wifi7for5G = {};
+
+for (var i = 0; i < WlanInfo.length; i++) {
+    if (WlanInfo[i].Name == 'ath0') {
+        wifi2G = WlanInfo[i];
+    } else if (WlanInfo[i].Name == 'ath4') {
+        wifi5G = WlanInfo[i];
+    } else if (isSupportMlo && (WlanInfo[i].Name == 'ath2')) {
+      wifi7for2G = WlanInfo[i];
+    } else if (isSupportMlo && (WlanInfo[i].Name == 'ath6')) {
+      wifi7for5G = WlanInfo[i];
+    }
+}
+
+function stWlan(domain, Enable, Name, SSID, BeaconType, Channel, BSSID, SSIDStatus) {
+    this.domain = domain;
+    this.Enable = Enable;
+    this.Name = Name;
+    this.SSID = SSID;
+    this.BeaconType = BeaconType;
+    this.Channel = Channel;
+    this.BSSID = BSSID;
+    this.SSIDStatus = SSIDStatus;
+}
+
+function GetWifiStatus(enable) {
+    if ((enable == undefined) || (enable.toUpperCase() == "DOWN")) {
+        return "Off";
+    }
+    if (language.toUpperCase() == "PORTUGUESE") {
+        return "Ativo";
+    } else {
+        return "On";
+    }
+}
+
+function GetBeaconType(beacontype) {
+    if (beacontype == 'Basic') {
+        return "Off";
+    } else if (beacontype == 'WPA') {
+        return "WPA";
+    } else if ((beacontype == '11i') || (beacontype == 'WPA2')) {
+        return "WPA2";
+    } else if ((beacontype == 'WPAand11i') || (beacontype == 'WPA/WPA2')) {
+        return "WPA/WPA2";
+    } else {
+        return beacontype;
+    }
+}
+
+function formatSeconds(value) {
+    var secondTime = parseInt(value);
+    var minuteTime = 0;
+    var hourTime = 0;
+    if (secondTime > 60) {
+        minuteTime = parseInt(secondTime / 60);
+        secondTime = parseInt(secondTime % 60);
+        if(minuteTime > 60) {
+            hourTime = parseInt(minuteTime / 60);
+            minuteTime = parseInt(minuteTime % 60);
+        }
+    }
+    var result = "" + parseInt(secondTime) + "s";
+
+    if (minuteTime > 0) {
+        result = "" + parseInt(minuteTime) + "mins" + result;
+    }
+    if (hourTime > 0) {
+        result = "" + parseInt(hourTime) + "hours" + result;
+    }
+    return result;
+}
+
+
+var wifi2tableArr = new Array();
+wifi2tableArr.push([GetLanguage("status001"), GetWifiStatus(wifi2G.SSIDStatus), ""]);
+wifi2tableArr.push(["SSID", wifi2G.SSID, ""]);
+wifi2tableArr.push([GetLanguage("status012"), wifi2G.BSSID, ""]);
+wifi2tableArr.push([GetLanguage("status021"), GetBeaconType(wifi2G.BeaconType), ""]);
+wifi2tableArr.push([GetLanguage("status022"), WlanChannel2g, ""]);
+
+var wifi7for2GtableArr = new Array();
+if (wifi7for2G.domain) {
+  wifi7for2GtableArr.push([GetLanguage("status001"), GetWifiStatus(wifi7for2G.SSIDStatus), ""]);
+  wifi7for2GtableArr.push(["SSID", wifi7for2G.SSID, ""]);
+  wifi7for2GtableArr.push([GetLanguage("status012"), wifi7for2G.BSSID, ""]);
+  wifi7for2GtableArr.push([GetLanguage("status021"), GetBeaconType(wifi7for2G.BeaconType), ""]);
+  wifi7for2GtableArr.push([GetLanguage("status022"), WlanChannel2g, ""]);
+}
+
+var wifi5tableArr = new Array();
+wifi5tableArr.push([GetLanguage("status001"), GetWifiStatus(wifi5G.SSIDStatus), ""]);
+wifi5tableArr.push(["SSID", wifi5G.SSID, ""]);
+wifi5tableArr.push([GetLanguage("status012"), wifi5G.BSSID, ""]);
+wifi5tableArr.push([GetLanguage("status021"), GetBeaconType(wifi5G.BeaconType), ""]);
+wifi5tableArr.push([GetLanguage("status022"), WlanChannel5g, ""]);
+
+var wifi7for5GtableArr = new Array();
+if (wifi7for5G.domain) {
+  wifi7for5GtableArr.push([GetLanguage("status001"), GetWifiStatus(wifi7for5G.SSIDStatus), ""]);
+  wifi7for5GtableArr.push(["SSID", wifi7for5G.SSID, ""]);
+  wifi7for5GtableArr.push([GetLanguage("status012"), wifi7for5G.BSSID, ""]);
+  wifi7for5GtableArr.push([GetLanguage("status021"), GetBeaconType(wifi7for5G.BeaconType), ""]);
+  wifi7for5GtableArr.push([GetLanguage("status022"), WlanChannel5g, ""]);
+}
+
+var systemtableArr = new Array();
+systemtableArr.push([GetLanguage("status031"), deviceInfos[0].Description, ""]);
+systemtableArr.push([GetLanguage("status032"), formatSeconds(deviceInfos[0].UpTime), ""]);
+systemtableArr.push([GetLanguage("status024"), deviceInfos[0].SerialNumber, ""]);
+systemtableArr.push([GetLanguage("status025"), deviceInfos[0].SoftwareVersion, ""]);
+systemtableArr.push([GetLanguage("status026"), deviceInfos[0].HardwareVersion, ""]);
+systemtableArr.push([GetLanguage("status027"), cpuUsed, ""]);
+systemtableArr.push([GetLanguage("status028"), memUsed, ""]);
+systemtableArr.push([GetLanguage("status029"), systemdsttime, ""]);
+
+var tableStyleArr = [45, 40, 15];
+
+function getStatus(val) {
+    if (language.toUpperCase() == "PORTUGUESE") {
+        return val == "1" ? "Ativo" : "Off";
+    } else {
+        return val == "1" ? "On" : "Off";
+    }
+}
+</script>
+</head>
+<body id="wanbody">
+<div id="content">
+<script>
+    CreatHeaderTitle(GetLanguage("status001"), GetLanguage("status002"));
+
+    if (typeWord != "BR") {
+        CreatStatusInfoTable(GetLanguage("status003"), "waninfotable", wantableArr, tableStyleArr);
+    }
+
+    CreatStatusInfoTable(GetLanguage("status004"), "laninfotable", lantableArr, tableStyleArr);
+
+    if (typeWord != "BR") {
+      CreatStatusInfoTable("Wi-Fi 2.4GHz", "wlaninfotable", wifi2tableArr, tableStyleArr);
+      if (wifi7for2G.domain) {
+        CreatStatusInfoTable("Wi-Fi 7 2.4GHz", "wlaninfotable72G", wifi7for2GtableArr, tableStyleArr);
+      }
+      CreatStatusInfoTable("Wi-Fi 5GHz", "wlaninfotable5g", wifi5tableArr, tableStyleArr);
+      if (wifi7for5G.domain) {
+        CreatStatusInfoTable("Wi-Fi 7 5GHz", "wlaninfotable75g", wifi7for5GtableArr, tableStyleArr);
+      }
+    }
+
+    CreatStatusInfoTable(GetLanguage("status005"), "laninfotable", systemtableArr, tableStyleArr);
+</script>
+</div>
+
+</body>
+</html>

--- a/tests/fixtures/huawei/getWlanPsw.asp
+++ b/tests/fixtures/huawei/getWlanPsw.asp
@@ -1,0 +1,39 @@
+function() {
+  function stWlan(domain, enable, name, BeaconType) {
+    this.domain = domain;
+    this.enable = enable;
+    this.name = name;
+    this.BeaconType = BeaconType;
+  }
+  var WlanInfo = dealArrayIfEmpty(new Array(new stWlan("InternetGatewayDevice\x2eLANDevice\x2e1\x2eWLANConfiguration\x2e1","1","ath0","11i"),new stWlan("InternetGatewayDevice\x2eLANDevice\x2e1\x2eWLANConfiguration\x2e2","0","ath1","11i"),new stWlan("InternetGatewayDevice\x2eLANDevice\x2e1\x2eWLANConfiguration\x2e3","0","ath2","WPA3"),new stWlan("InternetGatewayDevice\x2eLANDevice\x2e1\x2eWLANConfiguration\x2e4","0","ath6","WPA3"),new stWlan("InternetGatewayDevice\x2eLANDevice\x2e1\x2eWLANConfiguration\x2e5","1","ath4","11i"),new stWlan("InternetGatewayDevice\x2eLANDevice\x2e1\x2eWLANConfiguration\x2e6","0","ath5","11i"),null));
+
+  function stPreSharedKey(domain, psk, kpp) {
+    this.domain = domain;
+    this.value = psk;
+
+    if (kppUsedFlag === '1') {
+      this.value = kpp;
+    }
+  }
+  var kppUsedFlag = '0';
+  var wpaPskKey = dealArrayIfEmpty(new Array(new stPreSharedKey("InternetGatewayDevice\x2eLANDevice\x2e1\x2eWLANConfiguration\x2e1\x2ePreSharedKey\x2e1","REDACTED",""),new stPreSharedKey("InternetGatewayDevice\x2eLANDevice\x2e1\x2eWLANConfiguration\x2e2\x2ePreSharedKey\x2e1","REDACTED",""),new stPreSharedKey("InternetGatewayDevice\x2eLANDevice\x2e1\x2eWLANConfiguration\x2e3\x2ePreSharedKey\x2e1","REDACTED",""),new stPreSharedKey("InternetGatewayDevice\x2eLANDevice\x2e1\x2eWLANConfiguration\x2e4\x2ePreSharedKey\x2e1","REDACTED",""),new stPreSharedKey("InternetGatewayDevice\x2eLANDevice\x2e1\x2eWLANConfiguration\x2e5\x2ePreSharedKey\x2e1","REDACTED",""),new stPreSharedKey("InternetGatewayDevice\x2eLANDevice\x2e1\x2eWLANConfiguration\x2e6\x2ePreSharedKey\x2e1","REDACTED",""),null));
+
+  function stLanDevice(domain, WlanCfg) {
+    this.domain = domain;
+    this.WlanCfg = WlanCfg;
+  }
+  var LanDeviceArr = dealArrayIfEmpty(new Array(new stLanDevice("InternetGatewayDevice\x2eLANDevice\x2e1","1"),null));
+
+  function dealArrayIfEmpty(data) {
+    if(data) {
+      return data;
+    }
+    return [];
+  }
+
+  return {
+    WlanInfo,
+    wpaPskKey,
+    LanDeviceArr,
+  };
+}

--- a/tests/fixtures/huawei/getwanlist.asp
+++ b/tests/fixtures/huawei/getwanlist.asp
@@ -1,0 +1,71 @@
+function() {
+  var IPWanList = new Array(new WanIP("InternetGatewayDevice.WANDevice.1.WANConnectionDevice.1.WANIPConnection.1","0","0","AlwaysOn","","Connected","","","Internet","1","","","Connected","IP\x5fRouted","DHCP","203\x2e0\x2e113\x2e10","255\x2e255\x2e128\x2e0","","1","","192\x2e168\x2e1\x2e31\x2c192\x2e168\x2e1\x2e31","","","","","","Internet","","0","1","1","1","","","","","","","","","","","","105233","1",""),new WanIP("InternetGatewayDevice.WANDevice.1.WANConnectionDevice.2.WANIPConnection.1","0","0","AlwaysOn","","Connected","","","VoIP","1","","","Connected","IP\x5fRouted","DHCP","198\x2e51\x2e100\x2e10","255\x2e255\x2e192\x2e0","","1","","192\x2e0\x2e2\x2e1\x2c192\x2e0\x2e2\x2e2","","","","","","VoIP","","0","2","1","0","","","","","","","","","","","","105230","0",""),new WanIP("InternetGatewayDevice.WANDevice.1.WANConnectionDevice.3.WANIPConnection.1","0","0","AlwaysOn","","Connected","","","IPTV","1","","","Connected","IP\x5fRouted","DHCP","198\x2e51\x2e100\x2e20","255\x2e255\x2e128\x2e0","","1","","192\x2e0\x2e2\x2e3\x2c192\x2e0\x2e2\x2e4","","","","","","IPTV","","0","3","1","0","","","","","","","","","","","","105228","0",""),null);
+  var PPPWanList = new Array(null);
+  
+  var IPWanListNum = IPWanList.length - 1;
+  var PPPWanListNum = PPPWanList.length - 1;
+  var WanIdx = 0;
+  var WanList = new Array();
+  
+  for(var i=0; (IPWanList != null && IPWanListNum > 0 && i < IPWanListNum);i++)
+  {		
+    WanList[WanIdx] = new WanInfoInst();
+    ConvertIPWan(IPWanList[i], WanList[WanIdx]);
+    WanIdx++;
+  }
+  
+  for(var j=0; (null != PPPWanList && PPPWanListNum > 0 && j < PPPWanListNum); j++)
+  {	
+    WanList[WanIdx] = new WanInfoInst();
+    ConvertPPPWan(PPPWanList[j], WanList[WanIdx]);
+    WanIdx++;
+  }
+  
+  function IPv6AddressInfo(domain, IPAddressStatus, Origin,IPAddress,PreferredTime,
+                          ValidTime,ValidTimeRemaining)
+  {
+      this.WanInstanceId = domain.split(".")[4];
+      this.IPAddressStatus = IPAddressStatus;
+      this.Origin = Origin;
+      this.IPAddress = IPAddress;
+    this.PreferredTime = PreferredTime;
+    this.ValidTime = ValidTime;
+    this.ValidTimeRemaining = ValidTimeRemaining;
+  }
+  
+  var IPv6AddressList =  new Array(new IPv6AddressInfo("InternetGatewayDevice.WANDevice.1.X_HW_ShowInterface.1.IPv6Address.1","","None","2001\x3adb8\x3a1\x3a1\x3a\x3a1","","",""),new IPv6AddressInfo("InternetGatewayDevice.WANDevice.1.X_HW_ShowInterface.1.IPv6Address.2","","LinkLocal","fe80\x3a\x3a5669\x3a90ff\x3afe21\x3aaf55","","",""),null);
+  
+  function IPv6WanInfo(domain, Type, ConnectionStatus, L2EncapType, MACAddress, Vlan, Pri,
+                       DNSServers, AFTRName, AFTRPeerAddr,DefaultRouterAddress,V6UpTime)
+  {
+      this.WanInstanceId = domain.split(".")[4];
+      this.Type = Type;
+      this.ConnectionStatus = ConnectionStatus;
+      this.L2EncapType = L2EncapType;
+      this.MACAddress = MACAddress;
+      this.Vlan = Vlan;
+      this.Pri = Pri;
+    this.DNSServers = DNSServers;
+    this.AFTRName = AFTRName;
+    this.AFTRPeerAddr = (AFTRPeerAddr=="::")?"":AFTRPeerAddr;
+    this.DefaultRouterAddress = DefaultRouterAddress;
+      this.V6UpTime = V6UpTime;
+  }
+  
+  var IPv6WanInfoList =  new Array(new IPv6WanInfo("InternetGatewayDevice.WANDevice.1.X_HW_ShowInterface.1","WAN","Connected","IPoE","","","","","","","",""),new IPv6WanInfo("InternetGatewayDevice.WANDevice.1.X_HW_ShowInterface.2","WAN","Invalid","IPoE","","","","","","","",""),new IPv6WanInfo("InternetGatewayDevice.WANDevice.1.X_HW_ShowInterface.3","WAN","Invalid","IPoE","","","","","","","",""),null);
+  
+  
+  function AllWanInfoSt()
+  {
+    this.WanList = new Array(null);
+    this.IPv6AddressList = new Array(null);
+    this.IPv6WanInfoList = new Array(null);
+  }
+  var AllWanInfo = new AllWanInfoSt('','','');
+  AllWanInfo.WanList = WanList;
+  AllWanInfo.IPv6AddressList = IPv6AddressList;
+  AllWanInfo.IPv6WanInfoList = IPv6WanInfoList;
+  
+
+  return AllWanInfo;
+}

--- a/tests/fixtures/huawei/getwanlist.asp
+++ b/tests/fixtures/huawei/getwanlist.asp
@@ -33,7 +33,7 @@ function() {
     this.ValidTimeRemaining = ValidTimeRemaining;
   }
   
-  var IPv6AddressList =  new Array(new IPv6AddressInfo("InternetGatewayDevice.WANDevice.1.X_HW_ShowInterface.1.IPv6Address.1","","None","2001\x3adb8\x3a1\x3a1\x3a\x3a1","","",""),new IPv6AddressInfo("InternetGatewayDevice.WANDevice.1.X_HW_ShowInterface.1.IPv6Address.2","","LinkLocal","fe80\x3a\x3a5669\x3a90ff\x3afe21\x3aaf55","","",""),null);
+  var IPv6AddressList =  new Array(new IPv6AddressInfo("InternetGatewayDevice.WANDevice.1.X_HW_ShowInterface.1.IPv6Address.1","","None","2001\x3adb8\x3a1\x3a1\x3a\x3a1","","",""),new IPv6AddressInfo("InternetGatewayDevice.WANDevice.1.X_HW_ShowInterface.1.IPv6Address.2","","LinkLocal","fe80\x3a\x3a0000\x3a00ff\x3afe00\x3a0001","","",""),null);
   
   function IPv6WanInfo(domain, Type, ConnectionStatus, L2EncapType, MACAddress, Vlan, Pri,
                        DNSServers, AFTRName, AFTRPeerAddr,DefaultRouterAddress,V6UpTime)

--- a/tests/fixtures/huawei/html_bbsp_common_wanipv6state.asp
+++ b/tests/fixtures/huawei/html_bbsp_common_wanipv6state.asp
@@ -1,0 +1,115 @@
+﻿function IPv6AddressInfo(domain, IPAddressStatus, Origin,IPAddress,PreferredTime,
+                        ValidTime,ValidTimeRemaining)
+{
+    this.WanInstanceId = domain.split(".")[4];
+    this.IPAddressStatus = IPAddressStatus;
+    this.Origin = Origin;
+    this.IPAddress = IPAddress;
+	this.PreferredTime = PreferredTime;
+	this.ValidTime = ValidTime;
+	this.ValidTimeRemaining = ValidTimeRemaining;
+}
+function IPv6PrefixInfo(domain, Origin, Prefix,PreferredTime,ValidTime,ValidTimeRemaining)
+{
+    this.WanInstanceId = domain.split(".")[4];
+    this.Prefix = Prefix;
+    this.Origin = Origin;
+	this.PreferredTime = PreferredTime;
+	this.ValidTime = ValidTime;
+	this.ValidTimeRemaining = ValidTimeRemaining;
+}
+
+function IPv6WanInfo(domain, Type, ConnectionStatus, L2EncapType, MACAddress, Vlan, Pri,
+                     DNSServers, AFTRName, AFTRPeerAddr,DefaultRouterAddress,V6UpTime)
+{
+    this.WanInstanceId = domain.split(".")[4];
+    this.Type = Type;
+    this.ConnectionStatus = ConnectionStatus;
+    this.L2EncapType = L2EncapType;
+    this.MACAddress = MACAddress;
+    this.Vlan = Vlan;
+    this.Pri = Pri;
+	this.DNSServers = DNSServers;
+	this.AFTRName = AFTRName;
+	this.AFTRPeerAddr = (AFTRPeerAddr=="::")?"":AFTRPeerAddr;
+	this.DefaultRouterAddress = DefaultRouterAddress;
+    this.V6UpTime = V6UpTime;
+}
+
+var IPv6AddressList = [];
+var IPv6PrefixList = [];
+var IPv6WanInfoList = [];
+
+function GetIPv6AddressList(WanInstanceId)
+{
+    var List = new Array();
+    var Count = 0;
+    
+    for (var i = 0; i < IPv6AddressList.length; i++)
+    {
+        if(IPv6AddressList[i] == null)
+        continue;
+        
+        if (IPv6AddressList[i].WanInstanceId != WanInstanceId)
+        continue;
+        
+        List[Count++] = IPv6AddressList[i];
+    } 
+    
+    return List;
+}
+
+function GetIPv6PrefixList(WanInstanceId)
+{
+    var List = new Array();
+    var Count = 0;
+    
+    for (var i = 0; i < IPv6PrefixList.length; i++)
+    {
+        if(IPv6PrefixList[i] == null)
+        continue;
+        
+        if (IPv6PrefixList[i].WanInstanceId != WanInstanceId)
+        continue;
+        
+        List[Count++] = IPv6PrefixList[i];
+    } 
+    
+    return List;
+}
+
+function GetIPv6WanInfo(WanInstanceId)
+{
+    for (var i = 0; i < IPv6WanInfoList.length; i++)
+    {
+        if (IPv6WanInfoList[i] != null)
+        {
+            if (IPv6WanInfoList[i].WanInstanceId == WanInstanceId)
+            {
+                return IPv6WanInfoList[i];
+            }
+        }
+    }    
+}
+
+(function() {
+  var wanCacheObj = window.parent.wanCacheObj;
+  if (
+      (typeof wanCacheObj !== 'undefined')
+      && (typeof wanCacheObj.wanIpv6StateCacheObj !== 'undefined')
+      && (JSON.stringify(wanCacheObj.wanIpv6StateCacheObj) !== '{}')
+    ) {
+    var ipv6StateCache = wanCacheObj.wanIpv6StateCacheObj;
+    IPv6AddressList = ipv6StateCache.IPv6AddressList;
+    IPv6PrefixList = ipv6StateCache.IPv6PrefixList;
+    IPv6WanInfoList = ipv6StateCache.IPv6WanInfoList;
+  } else {
+    var result = ajaxGetAspData('/html/bbsp/common/wan_list_cache_wanipv6.asp');
+    IPv6AddressList = result.IPv6AddressList;
+    IPv6PrefixList = result.IPv6PrefixList;
+    IPv6WanInfoList = result.IPv6WanInfoList;
+    if (window.parent.wanCacheObj) {
+      window.parent.wanCacheObj.wanIpv6StateCacheObj = result;
+    }
+  }
+})();

--- a/tests/fixtures/huawei/index.asp
+++ b/tests/fixtures/huawei/index.asp
@@ -1,0 +1,1393 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+
+<html xmlns="http://www.w3.org/1999/xhtml" class=" js flexbox canvas canvastext webgl no-touch geolocation postmessage websqldatabase indexeddb hashchange history draganddrop websockets rgba hsla multiplebgs backgroundsize borderimage borderradius boxshadow textshadow opacity cssanimations csscolumns cssgradients cssreflections csstransforms csstransforms3d csstransitions fontface generatedcontent video audio localstorage sessionstorage webworkers applicationcache svg inlinesvg smil svgclippaths" style="background-color: #ebebeb;" lang="en">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+<title></title>
+<link rel="stylesheet" type="text/css" href="Cuscss/frame.css?03fa5651e1972f63229090335"/>      
+<script src="../resource/common/jquery.min.js?03fa5651e1972f63229090335" type="text/javascript"></script>
+<script src="../resource/common/util.js?03fa5651e1972f63229090335" type="text/javascript"></script>  
+<script language="JavaScript" src="Cusjs/ptvdfjs.js?03fa5651e1972f63229090335"></script>
+<script id="langResource" language="JavaScript" src="/frameaspdes/portuguese/ssmpdes.js?03fa5651e1972f63229090335"></script>  
+<script language="javascript" src="/html/bbsp/common/wan_list_ptvdf.asp"></script>
+<script language="javascript" src="/html/bbsp/common/wanipv6state.asp"></script>
+<style>
+#progress-bar-box {
+    background-color: #f7f7f7;
+    width: 316px;
+    height: 30px;
+    border: 1px solid #cccccc;
+}
+
+#progress-bar-image {
+    background-color: #a8b400;
+    width: 0px;
+    height: 29px;
+}
+</style>
+<script type="text/javascript">
+window.wanCacheObj = { wanListCacheObj:{}, wanIpv6StateCacheObj:{}, wanOptType: 0, curWanState: '0', wanMonitorTimer: null };
+
+function stDeviceInfo(domain, SoftwareVersion, UpTimeStr)
+{
+    this.domain = domain;
+    this.SoftwareVersion = SoftwareVersion;
+    this.UpTimeStr = UpTimeStr
+}
+var deviceInfos = new Array(new stDeviceInfo("InternetGatewayDevice.DeviceInfo","V5R024C00S114","1\x20day\x28s\x29\x2005\x3a14\x3a35"),null);
+var SoftwareVersion = deviceInfos[0].SoftwareVersion;
+var UpTimeStr = deviceInfos[0].UpTimeStr;
+
+var UpgradeFlag = 0;
+var upgradeStatusobj = {upgradeStatus:0};
+var InstallNodeMenu = null;
+var FirstMenuStr = "";
+var SecondTmpMenuStr = "";
+var g_ThirdMenuArry = [];
+var SecondMenuArray = [];
+var g_MenuList = [];
+var g_AllListMenuForJump = [];
+var activeMenuId = null;
+var g_clickshow = false;
+var curUserType = '1';
+var loginNum = '1';
+var sysUserType = '0';
+var ModeType = 'Expert Mode';
+var Var_DefaultLang = 'portuguese';
+var Var_LastLoginLang = 'portuguese';
+var Language ="";
+var CfgMode = 'PTVDF2WIFI_PWD'.toUpperCase();
+if(Var_LastLoginLang == '') {
+    Language = Var_DefaultLang;
+} else {
+    Language = Var_LastLoginLang;
+}
+
+
+$.ajax({
+    type : "POST",
+    async : false,
+    cache : false,
+    url : "asp/getMenuArray.asp",
+    success : function(data) {
+         InstallNodeMenu  = dealDataWithFun(data);
+    }
+});
+
+var UpgradeHeigthHandle = setInterval("setIframeHeight('functioncontent');", 200);
+function GetIdByUrl(Type, BaseUrl) {
+    var NewId = Type+"_";
+    var MarkEnd="";
+    try {
+        var lastindex = BaseUrl.lastIndexOf('/');
+        if (lastindex > -1) {
+            NewId += BaseUrl.substring(lastindex+1, BaseUrl.length);
+        } else {
+            NewId += BaseUrl;
+        }
+
+        if (NewId.indexOf("?") > -1) {
+            MarkEnd = NewId.split("?")[1];
+        }
+        NewId = NewId.split(".")[0]+MarkEnd;
+    }catch(e){
+        NewId += Math.round(Math.random() * 10000);
+    }
+    return NewId;
+}
+
+function GetMenuStr(datastr, length) {
+    if (datastr.length > length) {
+        var MenuName = GetStringContentForTitle(datastr, length);
+        return MenuName;
+    }
+    return datastr;
+}
+
+var comfimParentId ="";
+var comfimSpecialChildId ="";
+var wlanParaSyncFlag = false;
+
+function firstMenuSuceess() {
+    doOk("confirmblackBackground");
+    UpgradeFlag = 0;
+    onFirstMenuEvent(comfimParentId,comfimSpecialChildId);
+}
+
+function onFirstMenuChange(ParentId,SpecialChildId) {
+    showWifiPwdNote()
+    if (UpgradeFlag == 1) {
+        comfimParentId = ParentId;
+        comfimSpecialChildId = SpecialChildId;
+        confirmVDF(framedesinfo["frame040"],"firstMenuSuceess()");
+        return
+    } else {
+        onFirstMenuEvent(ParentId,SpecialChildId);
+    }
+}
+
+function onFirstMenuEvent(ParentId,SpecialChildId){
+    var ClickId = (SpecialChildId == null || SpecialChildId == undefined) ? null : "Child" + SpecialChildId;
+
+    $("#subnavigation_id").children().remove();
+    $('#clearfixtest').find("li").children('a').removeClass('addFirstMenu');
+    $('#' + ParentId).addClass('addFirstMenu');
+    for (var FirstMenuIndex in InstallNodeMenu) {
+        var id = InstallNodeMenu[FirstMenuIndex].id;
+        var subMenus = InstallNodeMenu[FirstMenuIndex].subMenus;
+
+        if (ParentId != id) {
+            continue;
+        }
+
+        g_MenuList[id] = new stMenuData(id, '', 1,
+                         InstallNodeMenu[FirstMenuIndex].deficon,
+                         InstallNodeMenu[FirstMenuIndex].clickicon,
+                         InstallNodeMenu[FirstMenuIndex].url, id);
+
+        if (undefined != subMenus) {
+            CreateSecondMenu(id, g_MenuList[id].path, subMenus,true);
+            g_MenuList[id].hasChild = true;
+        }
+        
+        break;
+    }
+
+    if (null == g_MenuList || false == g_MenuList[id].hasChild) {
+        $("#content-reset-wrap").css("width","950px");
+        $("#content-reset-wrap").css("margin-left","0px");
+        FirstPageURL = InstallNodeMenu[FirstMenuIndex].url;
+    } else {
+        $("#content-reset-wrap").css("width","710px");
+        $("#content-reset-wrap").css("margin-left","50px");
+
+    }
+
+    if("ChildonlyAppendArrayList" == ClickId) {
+        return;
+    }
+
+    if (null != ClickId) {
+        var subnavClickObj = null;
+        var subnavDiv = document.getElementById('subnavigation_id');
+        var LiObj = subnavDiv.getElementsByTagName('li');
+        var subnavLilistLength = subnavDiv.getElementsByTagName('li').length;
+        for (var i = 0;i < subnavLilistLength; i++){
+            var subnavDivObj = LiObj[i]; 
+            var subnavDivA = subnavDivObj.getElementsByTagName('a')[0];
+            if (ClickId == LiObj[i].id) {
+                subnavClickObj = subnavDivA; 
+                break;
+            }
+        }
+
+        if( (undefined != subnavClickObj) && (null != subnavClickObj) ) {
+            subnavClickObj.click();
+        }
+    } else {
+        if ('OverviewID' == ParentId) {
+            $("#functioncontent").attr("src", FirstPageURL);
+        } else {
+            var subnavDiv = document.getElementById('subnavigation_id');
+            var subnavDivA = subnavDiv.getElementsByTagName('a')[0];
+            subnavDivA.click();
+        }
+    }
+}
+var comfimid = "";
+var comfimSpecialChildId = "";
+
+function secondMenuSuceess() {
+    doOk("confirmblackBackground");
+    UpgradeFlag = 0;
+    onSecondMenuEvent(comfimid,comfimSpecialChildId);
+}
+
+function onSecondMenuChange(id,SpecialChildId) {
+    if (UpgradeFlag == 1) {
+        comfimid = id;
+        comfimSpecialChildId = SpecialChildId;
+        confirmVDF(framedesinfo["frame040"],"secondMenuSuceess()");
+        return
+    } else {
+        onSecondMenuEvent(id,SpecialChildId);
+    }
+}
+
+function onSecondMenuEvent(id,SpecialChildId) {
+    var ClickId = (SpecialChildId == null || SpecialChildId == undefined) ? null : SpecialChildId;
+    var SecondIndexId = "list_" + id;
+    $("#menu-title").empty();
+    $("#menu-usb").empty();
+    $(".sub-navigation").children('li').find('a').removeClass("third_click");
+    $("#" + id).addClass("third_click");
+    $(".sub-navigation").children('li').find('ul').fadeOut('fast');
+    $(".sub-navigation").children('li').find('a').addClass('second_click'); 
+    $("#functioncontent").attr("src", SecondMenuArray[id].ThirdMenuUrl);
+    
+    if (null != ClickId) {
+        $("#" + id).removeClass("second_click");
+        $("#" + id).siblings('ul').find('li').children('a').addClass("second_click_children");
+        $("#" + id).siblings('ul').fadeIn('fast');
+        $("#menu-usb").append(g_ThirdMenuArry[id].ThirdMenuList);
+        $("#menu-usb li:first a").addClass("active");
+        $("#" + id).removeClass("third_click");
+        var subnavClickObj = null;
+        var subnavDiv = document.getElementById(SecondIndexId);
+        var LiObj = subnavDiv.getElementsByTagName('li');
+        var subnavLilistLength = subnavDiv.getElementsByTagName('li').length;
+        for (var i = 0;i < subnavLilistLength; i++) {
+            var subnavDivObj = LiObj[i]; 
+            var subnavDivA = subnavDivObj.getElementsByTagName('a')[0];
+            if(ClickId == subnavDivA.id){
+                subnavClickObj = subnavDivA; 
+                break;
+            }
+        }
+
+        if( (undefined != subnavClickObj) && (null != subnavClickObj) ) {
+            console.log(subnavClickObj);
+            subnavClickObj.click();
+        }
+        return;
+    }
+    
+    
+    if (true == SecondMenuArray[id].hasChild) {
+        $("#" + id).removeClass("second_click");
+        $("#" + id).siblings('ul').find('li').children('a').addClass("second_click_children");
+        $("#" + id).siblings('ul').fadeIn('fast');
+        $("#menu-usb").append(g_ThirdMenuArry[id].ThirdMenuList);
+        $("#menu-usb li:first a").addClass("active");
+        
+        if (SecondMenuArray[id].ThirdMenuUrl != "") {
+            return;
+        } else {
+            $("#" + id).removeClass("third_click");
+        }
+        $("#" + id).siblings('ul').find('li').eq(0).children('a').addClass("third_click");
+        var subnavDiv = document.getElementById('subnavigation_id');
+        var subnavDivA = subnavDiv.getElementsByTagName('a')[0];
+        var subnavDivUl = subnavDivA.nextSibling;
+        if(null != subnavDivUl){
+            var subnavDivUlA = subnavDivUl.getElementsByTagName('a')[0];
+            subnavDivUlA.click();
+        }
+    }
+}
+
+function stSecondMenuTitle(id, secondtitle, ThirdMenuUrl, hasChild) {
+    this.id             = id;
+    this.secondtitle    = secondtitle;
+    this.ThirdMenuUrl   = ThirdMenuUrl;
+    this.hasChild       = hasChild;
+}
+
+function onThirdMenuChange(id,title) {
+    $(".sub-navigation").children('li').find('a').removeClass("third_click");
+    $(".thirdClass").children('li').find('a').removeClass("third_click");
+    $("#" + id).addClass("third_click");
+    $("#functioncontent").attr("src", g_MenuList[id].url);
+}
+
+function stMenuArrayList(id, MenuInfoList) {
+    this.id             = id;
+    this.MenuInfoList   = MenuInfoList;
+}
+
+function stThirdMenuList(id, ChildId, MenuInfoList) {
+    this.id             = id;
+    this.ChildId        = ChildId;
+    this.MenuInfoList   = MenuInfoList;
+}
+var confirmlanguage = "";
+function onChangeLanguage(language) {
+    if (UpgradeFlag == 1) {
+        confirmlanguage = language;
+        confirmVDF(framedesinfo["frame040"],"languageSuceess()");
+        return
+    } else {
+        changeLanguageEvent(language);
+    }
+}
+
+function languageSuceess() {
+    doOk("confirmblackBackground");
+    UpgradeFlag = 0;
+    changeLanguageEvent(confirmlanguage);
+}
+
+function changeLanguageEvent(language) {
+    var Form = new webSubmitForm();
+    Form.addParameter('language', language);
+    Form.addParameter('x.X_HW_Token', getAuthToken(true));
+    Form.setAction('setlanguage.cgi?'+'&RequestFile=index.asp');
+    Form.submit(); 
+}
+
+function selectDropUp(){
+    var iframewindow = document.getElementById('functioncontent').contentWindow;
+    var dropList = iframewindow.document.getElementsByName('dropDownList');
+    iframewindow.g_selectAllclickshow = false;
+    for(var i = 0; i< dropList.length; i++){
+        dropList[i].classList.add("noneDisplay");
+        dropList[i].previousSibling.style.backgroundImage ="url('../../../images/arrow-down.png')";
+    }
+}
+
+function psdStrength(ele) {
+    document.getElementById("functioncontent").contentWindow.psdStrength(ele);
+}
+
+function changePassword(ele) {
+    document.getElementById("functioncontent").contentWindow.changePassword(ele);
+}
+
+function AddKnownDevice() {
+    document.getElementById("functioncontent").contentWindow.AddKnownDevice();
+}
+
+function AddKnownLanDevice() {
+    document.getElementById("functioncontent").contentWindow.AddKnownLanDevice();
+}
+function selectDaysSelValue(ele) {
+    document.getElementById("functioncontent").contentWindow.selectDaysSelValue(ele);
+}
+
+function ChooseSSIDSelValue(ele) {
+    document.getElementById("functioncontent").contentWindow.ChooseSSIDSelValue(ele);
+}
+function ChooseStatusSelValue(ele) {
+    document.getElementById("functioncontent").contentWindow.ChooseStatusSelValue(ele);
+}
+function GetSelectVal(id, array) {
+    return document.getElementById("functioncontent").contentWindow.GetSelectVal(id, array);
+}
+
+function scheduleSave() {
+    document.getElementById("functioncontent").contentWindow.scheduleSave();
+}
+
+function SaveBoostTime() {
+    document.getElementById("functioncontent").contentWindow.SaveBoostTime();
+}
+
+function WlanBasicSubmit() {
+    hideWifiBlock();
+    document.getElementById("functioncontent").contentWindow.WlanBasicSubmit();
+}
+
+function resetPassword() {
+    doOk("confirmblackBackground");
+    document.getElementById("functioncontent").contentWindow.resetPassword();
+}
+
+function deletNameList() {
+    doOk("confirmblackBackground");
+    document.getElementById("functioncontent").contentWindow.deletNameList();
+}
+
+function uploadImage() {
+    doOk("confirmblackBackground");
+    document.getElementById("functioncontent").contentWindow.uploadImage();
+}
+
+function Reboot() {
+    doOk("confirmblackBackground");
+    document.getElementById("functioncontent").contentWindow.Reboot();
+}
+
+function deletMacline() {
+    doOk("confirmblackBackground");
+    document.getElementById("functioncontent").contentWindow.deletMacline();
+}
+
+function deletDevListFun() {
+    doOk("confirmblackBackground");
+    document.getElementById("functioncontent").contentWindow.deletDevListFun();
+}
+
+function submitCheck() {
+    doOk("confirmblackBackground");
+    document.getElementById("functioncontent").contentWindow.submitCheck();
+}
+
+function enableWifi7() {
+    doOk("confirmblackBackground");
+    document.getElementById("functioncontent").contentWindow.enableWifi7();
+}
+
+function disableAll() {
+    doOk("confirmblackBackground");
+    document.getElementById("functioncontent").contentWindow.disableAll();
+}
+
+function changeBWListMode() {
+    doOk("confirmblackBackground");
+    document.getElementById("functioncontent").contentWindow.changeBWListMode();
+}
+
+function rebackBWListMode() {
+    doOk("confirmblackBackground");
+    document.getElementById("functioncontent").contentWindow.rebackBWListMode();
+}
+function sucessNext() {
+    doOk("confirmblackBackground");
+    document.getElementById("functioncontent").contentWindow.sucessNext();
+}
+
+function sucessSub(){
+    doOk("confirmblackBackground");
+    document.getElementById("functioncontent").contentWindow.sucessSub();
+}
+
+function removeUsbInst(instId) {
+    doOk("confirmblackBackground");
+    document.getElementById("functioncontent").contentWindow.removeUsbInst(instId);
+}
+
+function checkFTPServer() {
+    doOk("confirmblackBackground");
+    document.getElementById("functioncontent").contentWindow.checkFTPServer();
+}
+
+function submitFtpData() {
+    doOk("confirmblackBackground");
+    document.getElementById("functioncontent").contentWindow.submitFtpData();
+}
+
+function mergeSSIDConfirm() {
+    doOk("confirmblackBackground");
+    document.getElementById("functioncontent").contentWindow.mergeSSIDConfirm();
+}
+
+function mergeSSIDSubmit() {
+    doOk("confirmblackBackground");
+    document.getElementById("functioncontent").contentWindow.mergeSSIDSubmit();
+}
+
+function checkNeedMerge() {
+    doOk("confirmblackBackground");
+    document.getElementById("functioncontent").contentWindow.checkNeedMerge();
+}
+
+function SetTransparentMode() {
+    doOk("confirmblackBackground");
+    document.getElementById("functioncontent").contentWindow.SetTransparentMode();
+}
+ 
+function CancleConfig() {
+    doOk("confirmblackBackground");
+    document.getElementById("functioncontent").contentWindow.CancleConfig();
+}
+
+function getRadioValue(sId) {
+    var item;
+    if (null == (item = getElement(sId))) {
+        debug(sId + " is not existed" );
+        return -1;
+    }
+
+    if (item.length > 0) {
+        for (i = 0; i < item.length; i++) {
+            if (item[i].checked == true) {
+                return item[i].value;
+            }
+        }
+    } else if (item.checked == true) {
+        return item.value;
+    }
+
+    return -1;
+}
+
+function hideWifiBlock() {
+    document.getElementById("wifiBackground").style.display = "none";
+    document.getElementById("wifiContent").style.display = "none";
+}
+
+function CancelGuestDuration() {
+    document.getElementById("wifiBackground").style.display = "none";
+    document.getElementById("wifiContent").style.display = "none";
+    document.getElementById("functioncontent").contentWindow.CancelGuestDura();
+    
+}
+
+function CancelAlertWifi() {
+    if (document.getElementById("wifiContent").style.display == "none") {
+        document.getElementById("wifiBackground").style.display = "none";
+    }
+    document.getElementById("wifiAlerrt").style.display = "none";
+}
+
+function AlertVDFWifi(value) {
+    document.getElementById("wifiBackground").style.display = "";
+    document.getElementById("wifiAlerrt").style.display = "";
+    document.getElementById("alertContent").innerHTML = value;
+}
+
+function goToTop(){
+    document.body.scrollIntoView();
+}
+</script>
+</head>
+<body onload="LoadFrame();" onclick = 'selectDropUp()'>
+<div class="blackBackgroundWifi" id="wifiBackground" style="display:none;">
+    <div class="popupWifi big add" id="wifiContent" style="display:none;">
+        
+    </div>
+    <div id="wifiAlerrt" class="alertpopupwifi" style="display:none;z-index:200px;">
+        <div class="alerttext">
+            <span id="alertContent"></span>
+        </div>
+        <div class="alertpop">
+            <input type="button" value="OK" onclick="CancelAlertWifi();" class="button button-apply W100">
+        </div>
+    </div>
+</div>
+<div id="look_3" class="lang-en mode-expert navigation-3of8 product-31 gateway-29" data-mode="mode-expert" data-language="lang-en" data-navigation-count="8">
+    <div class="rel">
+        <div id="header">
+            <div class="rel">   
+                <div id="top-bar">
+                    <div id="top-bar-content">
+                        <div id="logo_title" onclick="turnOverview(this.id)" BindText="frame010"></div>
+                        <script>
+                            if (CfgMode == 'ODIDO2') {
+                                document.getElementById('logo_title').setAttribute('BindText', 'frame010_ODIDO2');
+                            }
+                        </script>
+                        <div id="top-info" class="">
+                            <div id="top-info-logged-user">
+                                <div class="page-loader-container load-once" data-page-alias="top-info" data-has-loaded="true" data-page-id="3402">
+                                    <span class="language-string" id="users_logging" >
+                                    <span id="areinuse"></span>
+                                    </span>
+                                </div>
+                            </div>                                                                  
+                            <div class="dropdownSelect">
+                                <div class="dropdownShow" id="dropdownShow" onclick="showDropdown(event);"></div>
+                                <ul class="dropdownHide" id="dropdownHide" style="display:none"></ul>
+                            </div>
+                        </div>
+                        
+                    </div>
+                </div>
+            </div>
+            <div id="header-inner" class="clearfix">
+                <div id="rhombus-wrap">
+                    <a id="logo"></a>
+                    <script>
+                        if (CfgMode == 'ODIDO2') {
+                            let logoPath = '../images/hw_logo.gif'
+                            $('#logo').css("background-image", "url('"+ logoPath +"')");
+                        }
+                    </script>
+                    <div id="rhombus"></div>
+                </div>
+                <div id="rhombus-navigation" class="clearfix">
+                    <div class="rel">
+                        <div id="navigation">
+                            <ul class="clearfix" id="clearfixtest"></ul>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+        <div class="page-loader-container warning-messages" data-page-alias="warning-messages" data-page-id="3403">
+            <div id="globalMessages">
+                <div class="rel">
+                    <div class="global-wrap">
+                        <div class="head-message clearfix" id="psdNote" style="display: none;">
+                            <div class="fL">
+                                <span BindText="amp_wifi_basic_ptvdf2_tr181_alert_psd_note"></span>
+                            </div>
+                            <div class="head-button-message-wrap">
+                                <input type="button" value="dismiss" BindText="dismiss" id="dismiss" class="button button-cancel button-blank head2" onclick="dismissWifiPwdNote()">
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div id="content-wrap" class="clearfix rel">
+            <div id="indicator" class="visible" style="top: 67px;">
+                <div id="indicator-content"></div>
+            </div>  
+            <div id="subnavigation">
+                <div class="subnavigation-ALL" id="subnavigation_id"></div>
+            </div>
+
+                    <div id="content-reset-wrap" class="clearfix">
+                        <div class="white-background">
+                            <div id="content" class="content-ipv6-firewall-rules">
+                                <iframe id="functioncontent" frameborder="0" width="100%" height="370" marginheight="0" marginwidth="0" class="AspWidth" allowtransparency="true" scrolling="no" overflow="hidden" src="" style="z-index:301;position: relative;min-height:700px"></iframe>
+                            </div>
+                            <div id="fresh">
+                                <iframe frameborder="0" width="100%" height="100" marginheight="0" marginwidth="0" scrolling="no" src="refresh.asp"></iframe>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div id="footer">
+                    <div id="language-info" class="clearfix">
+                        <ul id="language-switcher-list">
+                            <li class="language-switcher" data-language-id="4">
+                                <a href="#" onClick="onChangeLanguage('english')" BindText="frame019"></a>
+                            </li>
+                            <li class="language-switcher" data-language-id="5">
+                                <a href="#" onClick="onChangeLanguage('portuguese')" BindText="frame020"></a>
+                            </li>
+                        </ul>
+                        <div class="page-loader-container load-once" data-page-alias="bottom-info" data-has-loaded="true" data-page-id="3505">
+                            <div id="info">
+                                <span class="language-string">
+                                    <span BindText="frame024"></span><i id="soft_time" style="font-style:normal"></i>
+                                </span><br>
+                                <span id="ipv4address" class="language-string">
+                                    <span BindText="frame025"></span><i id="ip4_address" style="font-style:normal"></i>
+                                </span><br> 
+                                <span id="ipv6address" class="language-string" >
+                                    <span BindText="frame026"></span><i id="ip6_address" style="font-style:normal"></i>
+                                </span><br> 
+                                <span id="conneuptimestr" class="language-string">
+                                    <span BindText="frame027"></span><i id="uptimestr" style="font-style:normal"></i>
+                                </span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="blackBackground" id="indexblackBackground" style="display:none;"></div>
+        <div class="blackBackground" id="alertblackBackground" style="z-index:301;display:none;">
+            <div id="alertFrom" class="alertpopup">
+                <div class="alerttext"><span id="alertspan"></span></div>
+                <div class="alertpop"><input id="alertbtn" type="button" value="OK" onclick="doOk('alertblackBackground')" class="button button-apply W100"/></div>
+            </div>
+        </div>
+        <div class="blackBackground" id="confirmblackBackground" style="z-index:301;display:none;">
+            <div id="confirmFrom" class="alertpopup">
+                <p class="title"><span id="confirmtitle"></span></p>
+                <div class="alerttext"><span id="confirmspan"></span></div>
+                <div class="confirmpop">
+                    <input id="confirmokbtn" type="button" value="Apply" onclick="" class="button button-apply W100"/>
+                    <input id="confirmnobtn" type="button" value="Cancel" onclick="doOk('confirmblackBackground')" class="button button-cancel W100"/>
+                </div>
+            </div>
+        </div>
+        <div class="blackBackground" id="informblackBackground" style="z-index:301;display:none;">
+            <div id="informFrom" class="alertpopup">
+                <div class="row"><img src="../../../images/icon-thinking.gif" alt="Loading..."></div>
+                <p class="title"><span id="informtitle"></span></p>
+                <div class="alerttext"><span id="informspan"></span></div>
+            </div>
+        </div>
+        <div class="blackBackground" id="progressblackBackground" style="z-index:301;display:none;">
+            <div id="progressFrom" class="alertpopup">
+                <p class="title"><span id="progresstitle"></span></p>
+                <div class="alerttext"><span id="progressspan"></span></div>
+                <div id="progress-bar-box"><div id="progress-bar-image"></div></div>
+            </div>
+        </div>
+        <div class="blackBackground" id="staticprogressblackBackground" style="z-index:301;display:none;">
+            <div id="staticprogressFrom" class="alertpopup">
+                <p class="title"><span id="staticprogresstitle"></span></p>
+                <div class="alerttext"><span id="staticprogressspan"></span></div>
+                <div class="row"><img src="images/progress.gif"></div>
+            </div>
+        </div>
+        <div class="blackBackground" id="alertExblackBackground" style="z-index:301;display:none;">
+            <div id="alertExFrom" class="alertpopup">
+                <p class="title"><span id="alertExtitle"></span></p>
+                <div class="alerttext"><span id="alertExspan"></span></div>
+                <div class="confirmpop"><input id="alertExbtn" type="button" value="OK" onclick="doOk('alertExblackBackground')" class="button button-apply W100"/></div>
+            </div>
+        </div>
+        <script language="javascript" src="/html/bbsp/common/getWanDynamicData.asp"></script>
+    </body>
+<script type="text/javascript">
+
+function doOk(id) {
+    document.getElementById(id).style.display = "none";
+}
+function setIframeHeight(iframeid) {
+    try{
+        var iframe = document.getElementById(iframeid);
+        if (iframe.attachEvent) {
+            try {
+                var doc = iframe.contentDocument || iframe.document;
+                var newheigth = iframe.contentWindow.document.documentElement.scrollHeight;
+                var Bodyheigth = doc.body.clientHeight; 
+            } catch(e) {
+                var newheigth = 370;
+                return;
+            }
+
+            newheigth = newheigth > 370 ? newheigth : 370;
+            newheigth = Bodyheigth < 370 ? 370 : Bodyheigth;
+
+            iframe.attachEvent("onload", function(){
+                iframe.height =  newheigth;
+                return;
+            });
+
+            iframe.height =  newheigth;
+            return;
+        } else {
+            try {
+                var newheigth = iframe.contentDocument.body.scrollHeight;
+                var doc = iframe.contentDocument || iframe.document;
+                var Bodyheigth = doc.body.clientHeight; 
+                newheigth = newheigth > 370 ? newheigth : 370;
+                newheigth = Bodyheigth < 370 ? 370 : Bodyheigth;
+            } catch(e) {
+                return ;
+            }
+
+            iframe.onload = function(){
+                iframe.height = newheigth;
+                return;
+            };
+
+            iframe.height = newheigth;
+            return;
+        }
+    }catch(e){
+        return;
+    }
+}
+var curLanguage = 'portuguese';
+function getMenuStrDefLen(level) {
+    var length = 0;
+    if(curLanguage.toUpperCase() == "ENGLISH") {
+        if (level == "first" ) {
+            length = 24;
+        } else {
+            length = 22;
+        }
+    } else {
+        if (level == "first" ) {
+            length = 22;
+        } else {
+            length = 20;
+        }
+    }
+    return length;
+}
+
+function GetMenuTitle(datastr, level, element) {
+    var length = getMenuStrDefLen(level);
+    var titlestr = "";
+    if (datastr.length > length) {
+        titlestr = ' title="' + datastr + '" ';
+        if (element != null)
+            element.setAttribute("title", datastr);
+    }
+    return titlestr;
+}
+
+function stMenuData(id, path, level, defico, clickico, url, defchild)
+{
+    this.id         = id;
+    this.path       = ((path == '') ? '' : (path + '.')) + id;
+    this.level      = level;
+    this.defico     = defico;
+    this.clickico   = clickico;
+    this.url        = url;
+    this.defchild   = defchild;
+    this.hasChild   = false;
+}
+
+function CreateSecondMenu(parentId, parentPath, subMenus,IsShowThirdMenu) {
+    var MenuSecondList = [];
+    SecondTmpMenuStr = "";
+    SecondTmpMenuStr +='<ul class="sub-navigation" ID="UL_' + parentId + '">';
+
+    for (var i in subMenus) {
+        var id = subMenus[i].id;
+        var name = subMenus[i].name
+        var MenuStr = GetMenuStr(name, 22);
+        var contenttitle ='<h3 id="title_'+ id + '" class="text-up">'+ subMenus[i].name + '</h3>';
+        SecondTmpMenuStr +='<li id="Child' + id + '"><a id="' + id + '" class="second_click" title="' + subMenus[i].name +'" onclick="onSecondMenuChange(this.id,null);">'+ MenuStr +'</a></li>';   
+        MenuSecondList[id] = new stMenuData(id, parentPath, 2,
+                                      subMenus[i].deficon,
+                                      subMenus[i].clickicon,
+                                      subMenus[i].url, id);
+
+        g_AllListMenuForJump[id] = new stMenuData(id, parentPath, 2,
+                                                subMenus[i].deficon,
+                                                subMenus[i].clickicon,
+                                                subMenus[i].url, id);
+
+        if (subMenus[i].subMenus != undefined) {
+            CreateThirdMenu(id, MenuSecondList[id].path, subMenus[i].subMenus,IsShowThirdMenu);
+            InitThirdMenuForJump(id, MenuSecondList[id].path, subMenus[i].subMenus);
+            MenuSecondList[id].hasChild = true;
+        }
+
+        SecondMenuArray[id] = new stSecondMenuTitle(id, contenttitle, subMenus[i].url, MenuSecondList[id].hasChild);
+    }
+    SecondTmpMenuStr +="</ul>";
+    
+    if (true != IsShowThirdMenu) {
+        return;
+    }
+
+    $("#subnavigation_id").append(SecondTmpMenuStr);
+
+    for (var i in SecondMenuArray) {
+        if (true != SecondMenuArray[i].hasChild) {
+            continue;
+        }
+
+        try{
+            var IndexId = SecondMenuArray[i].id;
+            var appendId = g_ThirdMenuArry[IndexId].ChildId;
+            var appendData = g_ThirdMenuArry[IndexId].MenuInfoList;
+            $("#"+appendId).append(appendData);
+        } catch(e) {
+            continue;
+        }
+    }
+}
+
+function CreateThirdMenu( parentId, parentPath, subMenus,IsShowThirdMenu)
+{
+    if (false == IsShowThirdMenu) {
+        return;
+    }
+
+    var MenuStrTemp = "";
+    var ChildLiId = "Child"+parentId;
+    MenuStrTemp +='<ul id="list_' + parentId + '" class="thirdClass" style="display:none">';
+    var MenusLenth = subMenus.length - 1;
+    for (var i in subMenus) {
+        var id = subMenus[i].id; 
+        g_MenuList[id] = new stMenuData(id, parentPath, 3,
+                                      subMenus[i].deficon,
+                                      subMenus[i].clickicon,
+                                      subMenus[i].url, id);
+
+        g_AllListMenuForJump[id] = new stMenuData(id, parentPath, 3,
+                                       subMenus[i].deficon,
+                                       subMenus[i].clickicon,
+                                       subMenus[i].url, id);
+        if (i == MenusLenth) {
+            MenuStrTemp +='<li><a id="' + id + '" style="border-right:0;" title="' + subMenus[i].name +'" onclick="onThirdMenuChange(this.id,this.title);">'+ subMenus[i].name +'</a></li>';    
+        } else {
+            MenuStrTemp +='<li><a id="' + id + '" title="' + subMenus[i].name +'" onclick="onThirdMenuChange(this.id,this.title);">'+ subMenus[i].name +'</a></li>';    
+        }
+    }
+    MenuStrTemp +='</ul>';
+
+    g_ThirdMenuArry[parentId] = new stThirdMenuList(parentId, ChildLiId, MenuStrTemp);
+}
+
+function InitThirdMenuForJump( parentId, parentPath, subMenus) {
+    var MenuStrTemp = "";
+    var ChildLiId = "Child"+parentId;
+    MenuStrTemp +='<ul id="list_' + parentId + '" class="thirdClass" style="display:none">';
+    var MenusLenth = subMenus.length - 1;
+    for (var i in subMenus) {
+        var id = subMenus[i].id; 
+        g_AllListMenuForJump[id] = new stMenuData(id, parentPath, 3,
+                                       subMenus[i].deficon,
+                                       subMenus[i].clickicon,
+                                       subMenus[i].url, id);
+    }
+}
+var FirstPageId = "OverviewID";
+var FirstPageURL = "";
+
+var menuAllButtonLength = 0;
+for(var FirstMenuIndex in InstallNodeMenu) {
+    var menuButtonlength = InstallNodeMenu[FirstMenuIndex].name.length;
+    menuAllButtonLength += menuButtonlength
+}
+
+var lastMenuLength = 950;
+for (var FirstMenuIndex in InstallNodeMenu) {
+    var m1namesr = GetIdByUrl("m1div",InstallNodeMenu[FirstMenuIndex].url);
+    var id = InstallNodeMenu[FirstMenuIndex].id;
+    var MenuButtonLength = parseInt((940 * InstallNodeMenu[FirstMenuIndex].name.length) / menuAllButtonLength);
+    if (FirstMenuIndex == InstallNodeMenu.length - 1) {
+        MenuButtonLength = lastMenuLength;
+    } else {
+        lastMenuLength = lastMenuLength - MenuButtonLength;
+    }
+    var MenuButtonWidth = MenuButtonLength + "px;";
+
+    FirstMenuStr += '<li style="width: '+ MenuButtonWidth +'"><a class="item" id="' + id + '" name="' + m1namesr + '" title="' + InstallNodeMenu[FirstMenuIndex].name +'" onclick="onFirstMenuChange(this.id,null);">' + InstallNodeMenu[FirstMenuIndex].name +'</a>';
+    g_MenuList[id] = new stMenuData(id, '', 1,
+                                    InstallNodeMenu[FirstMenuIndex].deficon,
+                                    InstallNodeMenu[FirstMenuIndex].clickicon,
+                                    InstallNodeMenu[FirstMenuIndex].url, id);
+
+    g_AllListMenuForJump[id] = new stMenuData(id, '', 1,
+                                              InstallNodeMenu[FirstMenuIndex].deficon,
+                                              InstallNodeMenu[FirstMenuIndex].clickicon,
+                                              InstallNodeMenu[FirstMenuIndex].url, id);
+ 
+    if(undefined != InstallNodeMenu[FirstMenuIndex].subMenus) {
+        CreateSecondMenu(id, g_MenuList[id].path, InstallNodeMenu[FirstMenuIndex].subMenus,false);
+        g_MenuList[id].hasChild = true;
+    }
+
+    if (id == FirstPageId && g_MenuList[id].hasChild == false) {
+        $("#content-reset-wrap").css("width","1000px");
+        $("#content-reset-wrap").css("margin-left","0px");
+        FirstPageURL = InstallNodeMenu[FirstMenuIndex].url;
+    }
+
+    FirstMenuStr +="</ul>";
+}
+
+$("#clearfixtest").append(FirstMenuStr);
+$("#functioncontent").attr("src", FirstPageURL);
+
+var typeWord = 'TR181';
+if (typeWord == "BR") {
+    onFirstMenuChange("SettingsID", "FirmwareUpdateID");
+    document.getElementById("ipv4address").style.display = "none";
+    document.getElementById("ipv6address").style.display = "none";
+    document.getElementById("conneuptimestr").style.display = "none";
+}
+
+function LoadFrame(){
+    $('#clearfixtest').find("li").children('a').first().addClass('addFirstMenu');
+    var ModeTypeStr = framedesinfo["frame022"];
+    if (curUserType == "0") {
+        ModeTypeStr = framedesinfo["frame021"];
+    }
+    $('#dropdownShow').html(ModeTypeStr);
+    var ShowHtml = loginNum +  framedesinfo["frame008"];
+    document.getElementById('areinuse').innerHTML = ShowHtml;
+    
+    var obj = document.getElementById("LANIPv4ID");
+    showWifiPwdNote()
+}
+
+function setLv1MenuStyle(id, flag, ifOnlyChangeStyle) {
+    var menu = g_AllListMenuForJump[id];
+    if (flag) {
+        $("#"+ id).addClass("addFirstMenu");
+
+        if ((ifOnlyChangeStyle != null) && (ifOnlyChangeStyle == "onlyshow")){
+            return menu;
+        }
+        if ((menu.defchild != menu.id)
+            && menu.hasChild){
+            return setLv2MenuStyle(menu.defchild, flag);
+        }
+    } else {
+        $("#" + id).removeClass("addFirstMenu");
+        $("#UL_" + id).css("display","none");
+    }
+
+    return menu;
+}
+
+function setLv2MenuStyle(id, flag, ifOnlyChangeStyle)
+{
+    var menu = g_AllListMenuForJump[id];
+    var FirstParentId = menu.path.split('.')[0];
+    var SecondParentId = menu.path.split('.')[1];
+    if (flag) {
+        setLv1MenuStyle(FirstParentId, flag, "onlyshow");
+
+        if (!menu.hasChild){
+            $("#" + id).addClass("third_click");
+        }
+
+        if ((ifOnlyChangeStyle != null) && (ifOnlyChangeStyle == "onlyshow")){
+            
+            onFirstMenuChange(FirstParentId,"onlyAppendArrayList");
+            onSecondMenuChange(SecondParentId,menu.id);
+            return menu;
+        }
+
+        if ((menu.defchild != menu.id) && menu.hasChild) {
+            $("#" + id).removeClass("second_click");
+            $("#" + id).addClass("third_click");
+            return setLv3MenuStyle(menu.defchild, flag);
+        } else {
+            onFirstMenuChange(FirstParentId,menu.id);
+        }
+    } else {
+        $("#" + id).remoceClass("second_click");
+    }
+    return menu;
+}
+
+function setLv3MenuStyle(id, flag) {
+    var menu = g_AllListMenuForJump[id];
+
+    if (id == "") {
+        id="menuid_3";
+    }
+
+    if (flag) {
+        var FirstParentID = menu.path.split('.')[0];
+        var parentId = menu.path.split('.')[1];
+
+        setLv2MenuStyle(menu.id, flag, "onlyshow");
+
+        $("#"+id).addClass("third_click");
+    } else {
+        $("#"+id).removeClass("third_click");
+    }
+    return menu;
+}
+
+function deactiveMenuStyle(DeactiveId) {
+    var id = DeactiveId;
+    var menu = g_AllListMenuForJump[id];
+
+    if (menu == null)
+        return ;
+
+    var ids = menu.path.split('.');
+    switch(menu.level) {
+        case 3:
+            setLv3MenuStyle(ids[2], false);
+        case 2:
+            setLv2MenuStyle(ids[1], false);
+        default:
+            setLv1MenuStyle(ids[0], false);
+    }
+}
+
+function activeMenuStyle(id) {
+    var menu = g_AllListMenuForJump[id];
+    if (menu == null) {
+        return null;
+    }
+
+    var ids = menu.path.split('.');
+    switch(menu.level) {
+        case 3:
+            menu = setLv3MenuStyle(ids[2], true);
+            break;
+        case 2:
+            menu = setLv2MenuStyle(ids[1], true);
+            break;
+        default:
+            menu = setLv1MenuStyle(ids[0], true);
+            break;
+    }
+    return menu;
+}
+
+function changeCrossLvMenuStyle(oldId, newId) {
+    var oldMenu = g_AllListMenuForJump[oldId];
+    var newMenu = g_AllListMenuForJump[newId];
+
+    if ((oldMenu == null) || (newMenu == null))
+        return;
+
+    if (oldMenu.level == newMenu.level) {
+        switch (oldMenu.level) {
+            case 3:
+                var lv2id_o = oldMenu.path.split('.')[1];
+                var lv2id_n = newMenu.path.split('.')[1];
+                if (lv2id_o != lv2id_n) {
+                    $("#" + lv2id_o + "_menu").addClass("Menuhide");
+                    $("#" + lv2id_n + "_menu").removeClass("Menuhide");
+                } else {
+                    $("#pointer_" + lv2id_n).removeClass("SecondMenuPointer");
+                    $("#pointer_" + lv2id_n).addClass("SecondMenuPointerBlock");
+                }
+            case 2:
+                var lv1id_o = oldMenu.path.split('.')[0];
+                var lv1id_n = newMenu.path.split('.')[0];
+                if (lv1id_o != lv1id_n) {
+                    $("#" + lv1id_o + "_subMenus").addClass("Menuhide");
+                    $("#" + lv1id_n + "_subMenus").removeClass("Menuhide");
+                }
+            default:
+                break;
+        }
+    }
+    else if (oldMenu.level < newMenu.level)
+    {
+        var lv1id_n = newMenu.path.split('.')[0];
+        var lv1id_o = oldMenu.path.split('.')[0];
+
+        if (lv1id_o != lv1id_n)
+            $("#" + lv1id_o + "_subMenus").addClass("Menuhide");
+            $("#" + lv1id_n + "_subMenus").removeClass("Menuhide");
+            $("#SecondMenuInfo").removeClass("Menuhide");
+            $("#SecondMenuInfo").addClass("Menushow");
+        if (newMenu.level > 2) {
+            var lv2id = newMenu.path.split('.')[1];
+            $("#" + lv2id + "_menu").removeClass("Menuhide");
+        }
+        if (oldMenu.level < 2) {
+            expandFirstMenuTitle(false);
+        }
+    } else {
+        if (oldMenu.level > 2) {
+            var lv2id = oldMenu.path.split('.')[1];
+            $("#"+lv2id+"_menu").addClass("Menuhide");
+        }
+
+        if (newMenu.level < 2) {
+            var lv1id = oldMenu.path.split('.')[0];
+            $("#" + lv1id + "_subMenus").addClass("Menuhide");
+            $("#SecondMenuInfo").removeClass("Menushow");
+            $("#SecondMenuInfo").addClass("Menuhide");
+            expandFirstMenuTitle(true);
+        } else {
+            var lv1id_o = oldMenu.path.split('.')[0];
+            var lv1id_n = newMenu.path.split('.')[0];
+            if (lv1id_o != lv1id_n) {
+                $("#" + lv1id_o + "_subMenus").addClass("Menuhide");
+                $("#" + lv1id_n + "_subMenus").removeClass("Menuhide");
+            }
+        }
+    }
+}
+
+function expandFirstMenuTitle(flag) {
+    var id;
+    var action = ((flag == true) ? "block" : "none");
+
+    $('#MenuFirstLineMid').css("display", action);
+    $('#MenuBottomLineMid').css("display", action);
+
+    for (var tmp in g_AllListMenuForJump) {
+        if (g_AllListMenuForJump[tmp].level != 1) continue;
+        id = "name_" + g_AllListMenuForJump[tmp].id;
+        $('#' + id).css("display", action);
+    }
+}
+
+function turnOverview(ParaId) {
+    location.reload();
+}
+
+function logoutCheck() {
+    if (UpgradeFlag == 1) {
+        alertVDF(framedesinfo["frame042"]);
+    } else {
+        logoutfunc();
+    }
+}
+
+function showLogUsers() {
+    var oSpan = document.getElementById('users_logging');
+    var oStrong = oSpan.getElementsByTagName('strong')[0];
+    oStrong.innerHTML = loginNum ;
+}
+
+function showDropdown(event) {
+    var modeUlStr = (curUserType == sysUserType)?framedesinfo["frame021"]:framedesinfo["frame022"];
+    $("#dropdownHide").html("<li>"+modeUlStr+"</li><li onclick='logoutCheck();' >"+ framedesinfo["frame023"] +"</li>")
+    $("#dropdownHide").toggle(function(){
+        if(false == g_clickshow){
+            $('#dropdownShow').css("background-image","url('../images/arrow-up.png')");
+            g_clickshow = true;
+        }else{
+            g_clickshow = false;
+            $('#dropdownShow').css("background-image","url('../images/arrow-down.png')");
+        }
+    });
+
+    $("body").click(function(){
+        $("#dropdownHide").hide();
+        g_clickshow = false;
+        $('#dropdownShow').css("background-image","url('../images/arrow-down.png')");
+    });
+    var e = window.event || event;
+    if(e.stopPropagation){
+        e.stopPropagation();
+    }else{
+        window.event.cancelBubble = true;
+    }
+}
+
+var wanInfoAll = GetWanList();
+var curIPv4Address = "- - - -";
+var curIPv6Address = "- - - -";
+var curWanMacId = ""
+
+for (var i = 0; i < wanInfoAll.length; i++) {
+    if ((wanInfoAll[i].ServiceList.toUpperCase().indexOf("INTERNET") >= 0) && (wanInfoAll[i].Status.toUpperCase() == "UP")) {
+        curWanMacId = wanInfoAll[i].MacId;
+        curIPv4Address = wanInfoAll[i].IPAddress;
+        break;
+    }
+}
+
+var curIPv6AddressList = GetIPv6AddressList(curWanMacId);
+if (curIPv6AddressList.length != 0) {
+    curIPv6Address = curIPv6AddressList[0].IPAddress;
+}
+
+$('#ip4_address').text(curIPv4Address);
+$('#ip6_address').text(curIPv6Address);
+
+$('#soft_time').text(SoftwareVersion);
+$('#uptimestr').text(UpTimeStr);
+
+var IframeOnclick = {
+    resolution: 500,
+    iframes:[],
+    interval:null,
+    Iframe:function(){
+        this.element = arguments[0];
+        this.cd = arguments[1];
+        this.hasTracked = false;
+    },
+    track:function(element,cd){
+        this.iframes.push(new this.Iframe(element,cd));
+        if(!this.interval){
+            var _this = this;
+            this.interval = setInterval(function(){
+                _this.checkClick();
+            },this.resolution);
+        }
+    },
+    checkClick:function(){
+        if(document.activeElement){
+            var activeElement = document.activeElement;
+            for(var i in this.iframes){
+                if(activeElement === this.iframes[i].element){
+                    if(this.iframes[i].hasTracked ==  false){
+                        this.iframes[i].cd.apply(window,[]);
+                        this.iframes[i].hasTracked = true;
+                    }
+                }else{
+                    this.iframes[i].hasTracked = false;
+                }
+            }
+        }
+    }
+}
+
+IframeOnclick.track(document.getElementById("functioncontent"),function(){
+    $("#dropdownHide").hide();
+})
+
+function GetLanguageDesc(Name) {
+    return framedesinfo[Name];
+}
+
+function isShowWifiPswTips() {
+  var wlanPswData = getWlanPswData();
+
+  if (!isWifiEnable(wlanPswData.LanDeviceArr)) {
+    return false;
+  }
+
+  var wifiNameMap = {
+    '2g': 'ath0',
+    '5g': 'ath4',
+    'guest2g': 'ath1',
+    'guest5g': 'ath5',
+  };
+  for (var key in wifiNameMap) {
+    var isStrong = checkSsidPsw(wifiNameMap[key], wlanPswData.WlanInfo, wlanPswData.wpaPskKey);
+    if (!isStrong) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function getWlanPswData() {
+  var res = {};
+  $.ajax({
+    type: 'GET',
+    async: false,
+    cache: false,
+    timeout: 10000,
+    url: '/html/amp/ptvdf/getWlanPsw.asp',
+    success: function(data) {
+      res = dealDataWithFun(data);
+    }
+  });
+  return res;
+}
+
+function isWifiEnable(LanDeviceArr) {
+  var LanDevice = LanDeviceArr[0];
+  var enbl = LanDevice.WlanCfg;
+  return enbl === '1';
+}
+
+function checkSsidPsw(name, WlanInfo, wpaPskKey) {
+  var ssidIdx = getSsidIdxByName(name, WlanInfo);
+  if(ssidIdx < 0) {
+    return true;
+  }
+  var ssidWlanInfo = WlanInfo[ssidIdx];
+
+  if (ssidWlanInfo.enable !== '1') {
+    return true;
+  }
+
+  var authMode = ssidWlanInfo.BeaconType;
+  if (!isWlanModeHasPsw(authMode)) {
+    return true;
+  }
+
+  var psw =  wpaPskKey[ssidIdx] && wpaPskKey[ssidIdx].value;
+  if(!psw) {
+    return true;
+  }
+  return isPswComplex(psw);
+}
+
+function getSsidIdxByName(name, WlanInfo) {
+  return WlanInfo.findIndex(item => item && item.name === name);
+}
+
+function isWlanModeHasPsw(authMode) {
+  var modeArrHasPsw = ['WPA', '11i', 'WPA2', 'WPAand11i', 'WPA/WPA2', 'WPA3', 'WPA2/WPA3'];
+  return modeArrHasPsw.includes(authMode);
+}
+
+function isPswComplex(str) {
+  var G_MIN_PSK_LENGTH = 12;
+  if (str.length < G_MIN_PSK_LENGTH) {
+    return false;
+  }
+  var lowerFlag = false;
+  var upperFlag = false;
+  var numberFlag = false;
+  if (str.match(/[a-z]/)) {
+    lowerFlag = true;
+  }
+  if (str.match(/[A-Z]/)) {
+    upperFlag = true;
+  }
+  if (str.match(/\d/)) {
+    numberFlag = true;
+  }
+  return (lowerFlag && upperFlag && numberFlag);
+}
+
+ParseBindTextByTagName(framedesinfo, "div",    1);
+ParseBindTextByTagName(framedesinfo, "span",    1);
+ParseBindTextByTagName(framedesinfo, "td",    1);
+ParseBindTextByTagName(framedesinfo, "input",    2);
+ParseBindTextByTagName(framedesinfo, "h1", 1);
+ParseBindTextByTagName(framedesinfo, "a", 1);
+
+function dismissWifiPwdNote() {
+    document.getElementById("psdNote").style.display = "none";
+}
+function showWifiPwdNote() {
+    if ((typeWord != "BR") && isShowWifiPswTips() && (curUserType == '1')) {
+        document.getElementById("psdNote").style.display = "block";
+    }else {
+        dismissWifiPwdNote();
+    }
+}
+
+</script>
+</html>

--- a/tests/fixtures/huawei/login_page.html
+++ b/tests/fixtures/huawei/login_page.html
@@ -1,0 +1,301 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+  class=" js flexbox canvas canvastext webgl no-touch geolocation postmessage websqldatabase indexeddb hashchange history draganddrop websockets rgba hsla multiplebgs backgroundsize borderimage borderradius boxshadow textshadow opacity cssanimations csscolumns cssgradients cssreflections csstransforms csstransforms3d csstransitions fontface generatedcontent video audio localstorage sessionstorage webworkers applicationcache svg inlinesvg smil svgclippaths"
+  style="background-color: #ebebeb;" lang="en">
+
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+  <title></title>
+  <link href="Cuscss/login.css" media="all" rel="stylesheet" />
+  <link rel="stylesheet" type="text/css" href="Cuscss/frame.css?03fa5651e1972f0229090335" />
+  <link rel="stylesheet" type="text/css" href="Cuscss/login.css?03fa5651e1972f0229090335" />
+  <link href="/html/web/a11y/css/accessbilitySwitch.css?03fa5651e1972f0229090335" rel="stylesheet" type="text/css" />
+  <script language="JavaScript" src="../resource/common/RndSecurityFormat.js?03fa5651e1972f0229090335"></script>
+  <script language="JavaScript" src="../resource/common/jquery.min.js?03fa5651e1972f0229090335"></script>
+  <script language="JavaScript" src="../resource/common/safelogin.js?03fa5651e1972f0229090335"></script>
+  <script src="/html/web/a11y/js/accessbilitySwitch.js?03fa5651e1972f0229090335" language="JavaScript"></script>
+  <script language="JavaScript" type="text/javascript">
+    var FailStat = '0';
+    var LoginTimes = '0';
+    var ModeCheckTimes = '0';
+    var Var_DefaultLang = 'portuguese';
+    var LockLeftTime = '0';
+    var errloginlockNum = '3';
+    var locklefttimerhandle;
+    var APPVersion = '1.1.1.1';
+    var productName = 'HG8247B7\x2d8N'.toUpperCase();
+    var Var_LastLoginLang = 'portuguese';
+    var Language = '';
+    var CfgMode = 'PTVDF2WIFI_PWD'.toUpperCase();
+
+    if (CfgMode == '') {
+      window.location.reload();
+    }
+
+    if (Var_LastLoginLang == '') {
+      Language = Var_DefaultLang;
+    } else {
+      Language = Var_LastLoginLang;
+    }
+
+    function GetLoginDes(DesId) {
+      return framedesinfo[DesId];
+    }
+
+    function showlefttime() {
+      LockLeftTime--;
+      if (LockLeftTime <= 0) {
+        window.location = "/login.asp";
+        return;
+      }
+      var html = GetLoginDes("frame011a") + LockLeftTime + GetLoginDes(LockLeftTime == 1 ? "frame012c" : "frame012d");
+      SetDivValue("DivErrPage", html);
+    }
+
+    function setErrorStatus() {
+      clearInterval(locklefttimerhandle);
+      if (LoginTimes > 0 || FailStat == "1" || (+ModeCheckTimes) >= errloginlockNum) {
+        document.getElementById('error-message').style.display = 'block';
+      }
+      if (FailStat == "1") {
+        SetDivValue("DivErrPage", GetLoginDes("frame013"));
+        setDisable('username', 1);
+        setDisable('userpwd', 1);
+
+        document.getElementById("loginbtn").classList.add("op40");
+      } else if (((+LoginTimes >= errloginlockNum) || (+ModeCheckTimes >= errloginlockNum)) && LockLeftTime > 0) {
+        var html = GetLoginDes("frame011a") + LockLeftTime + GetLoginDes(LockLeftTime == 1 ? "frame012c" : "frame012d");
+        SetDivValue("DivErrPage", html);
+        setDisable('username', 1);
+        setDisable('userpwd', 1);
+
+        document.getElementById("loginbtn").classList.add("op40");
+        locklefttimerhandle = setInterval('showlefttime()', 1000);
+      } else if (LoginTimes > 0 && +LoginTimes < errloginlockNum) {
+        SetDivValue("DivErrPage", GetLoginDes("frame014"));
+      } else {
+        document.getElementById('error-message').style.display = 'none';
+      }
+    }
+
+    function SubmitForm() {
+      var Password = document.getElementById('userpwd');
+      var Username = document.getElementById('username');
+      var appName = navigator.appName;
+      var version = navigator.appVersion;
+
+      if (appName == "Microsoft Internet Explorer") {
+        var versionNumber = version.split(" ")[3];
+        if (parseInt(versionNumber.split(";")[0]) < 6) {
+          alert(GetLoginDes('frame006'));
+          return false;
+        }
+      }
+
+      if (Password.value == "") {
+        document.getElementById('error-message').style.display = 'block';
+        SetDivValue("DivErrPage", GetLoginDes("frame009"));
+        Password.focus();
+        return false;
+      }
+
+      var cnt;
+
+      $.ajax({
+        type: "POST",
+        async: false,
+        cache: false,
+        url: '/asp/GetRandCount.asp',
+        success: function (data) {
+          cnt = data;
+        }
+      });
+
+      var Form = new webSubmitForm();
+      var cookie2 = "Cookie=body:" + "Language:" + Language + ":" + "id=-1;path=/";
+      Form.addParameter('UserName', Username.value);
+      Form.addParameter('PassWord', base64encode(Password.value));
+      Form.addParameter('Language', Language);
+      document.cookie = cookie2;
+
+      Password.disabled = true;
+
+      Form.addParameter('x.X_HW_Token', cnt);
+      Form.setAction('/login.cgi');
+      Form.submit();
+      return true;
+    }
+
+    function IsIEBrower(num) {
+      var ua = navigator.userAgent.toLowerCase();
+      var isIE = ua.indexOf("msie") > -1;
+      var safariVersion;
+      if (isIE) {
+        safariVersion = ua.match(/msie ([\d.]+)/)[1];
+        var sa = parseInt(safariVersion);
+        if (safariVersion <= num) {
+          alert(framedesinfo["frame018"]);
+        }
+      }
+    }
+    function LoadFrame() {
+      if (typeof generateSwitch !== 'undefined') {
+        let mode = 'Accessibility Mode';
+
+        if (Language === 'portuguese') {
+          mode = 'Modo de acessibilidade';
+        }
+        generateSwitch('header', mode);
+      }
+      onChangeLanguage();
+      clearInterval(locklefttimerhandle);
+      setOntImage();
+      setOntLogo();
+      init();
+    }
+
+    function setOntImage() {
+      let image = 'ONT_Fiber_PT.jpg';
+      if (productName === 'HN8255X6S-8X') {
+        image = 'HN8255X6s-8X.jpg';
+      }
+      image = '../images/' + image;
+      $("#ontImg").css("background-image", "url('"+ image +"')");
+    }
+
+    function setOntLogo() {
+      if (CfgMode == 'ODIDO2') {
+         let logoPath = '../images/hw_logo.gif'
+         $('#ontLogo').css("background-image", "url('"+ logoPath +"')");
+      }
+    }
+
+    function init() {
+      if (document.addEventListener) {
+        document.addEventListener("keypress", onHandleKeyDown, false);
+      } else {
+        document.onkeypress = onHandleKeyDown;
+      }
+    }
+
+    function onHandleKeyDown(event) {
+      var e = event || window.event;
+      var code = e.charCode || e.keyCode;
+
+      if (code == 13) {
+        SubmitForm();
+      }
+    }
+
+    function loadLanguage(id, url, callback) {
+      var docHead = document.getElementsByTagName('head')[0];
+      var langScript = document.getElementById(id);
+      if (langScript != null) {
+        docHead.removeChild(langScript);
+      }
+
+      try {
+        langScript = document.createElement('script');
+        langScript.setAttribute('type', 'text/javascript');
+        langScript.setAttribute('src', url);
+        langScript.setAttribute('id', id);
+        if (callback != null) {
+          langScript.onload = langScript.onreadystatechange = function () {
+            if (langScript.ready) {
+              return false;
+            }
+            if (!langScript.readyState || langScript.readyState == "loaded" || langScript.readyState == 'complete') {
+              langScript.ready = true;
+              callback();
+            }
+          };
+        }
+        docHead.appendChild(langScript);
+      }
+      catch (e) { }
+    }
+
+    function onChangeLanguage(language) {
+      if (language != null) {
+        if (Language == language) {
+          return;
+        }
+        Language = language;
+      }
+      var langSrc = "/frameaspdes/" + Language + "/ssmpdes.js";
+      loadLanguage("langResource", langSrc, onLanguageChanged);
+    }
+
+    function onLanguageChanged() {
+      document.getElementById('username').placeholder = GetLoginDes('username_placeholder');
+      document.getElementById('userpwd').placeholder = GetLoginDes('password_placeholder');
+      if (Language == "english") {
+        document.getElementById('loginbtn').style.width = '90px';
+      } else {
+        document.getElementById('loginbtn').style.width = '130px';
+      }
+      ParseBindTextByTagName(framedesinfo, "a", 1);
+      ParseBindTextByTagName(framedesinfo, "input", 2);
+      ParseBindTextByTagName(framedesinfo, "span", 1);
+      ParseBindTextByTagName(framedesinfo, "div", 1);
+
+      setErrorStatus();
+
+      if (CfgMode == 'ODIDO2') {
+        $('#footer').hide();
+      }
+
+      const a11yTextDom = document.querySelector('.a11y-text');
+      if (a11yTextDom) {
+        let mode = 'Accessibility Mode';
+
+        if (Language === 'portuguese') {
+          mode = 'Modo de acessibilidade';
+        }
+
+        a11yTextDom.textContent = mode;
+      }
+    }
+  </script>
+</head>
+
+<body onLoad="LoadFrame();">
+  <div id="header" style="width:100%;height:155px;background-color:white;padding: 65px 0 0 20%;" class="a11y-container">
+    <div id="ontLogo" class="logoimages"></div>
+  </div>
+  <div id="mainbody" style="width:100%;height:545px;background-color:white;display: flex;justify-content: center;">
+    <div class="logodiv">
+      <div id="ontImg" class="ontimages"></div>
+    </div>
+    <div id="logindiv" style="padding-top:20px">
+      <div id="welcomdiv">
+        <span id="logintitle" class="welcomspan" BindText="frame028"></span>
+      </div>
+      <div class="loginrow" style="width:500px"><span id="logintips" BindText="frame029a"></span></div>
+      <div class="loginrow"><input id="username" placeholder="Username" type="text" class="inputdiv"></div>
+      <div class="loginrow">
+        <input id="userpwd" placeholder="Password" type="password" class="inputdiv">
+        <input type="button" id="loginbtn" class="button button-apply" name="login" BindText="frame007a"
+          onClick="SubmitForm();">
+      </div>
+      <div class="loginrow" id="error-message">
+        <div id="DivErrPage" style="color: #e60000;"></div>
+      </div>
+    </div>
+  </div>
+  <div id="footer">
+    <div id="language-info" class="clearfix">
+      <ul id="language-switcher-list">
+        <li class="language-switcher" data-language-id="4">
+          <a href="#" onClick="onChangeLanguage('english')" BindText="frame019"></a>
+        </li>
+        <li class="language-switcher" data-language-id="5">
+          <a href="#" onClick="onChangeLanguage('portuguese')" BindText="frame020"></a>
+        </li>
+      </ul>
+    </div>
+  </div>
+</body>
+
+</html>

--- a/tests/fixtures/huawei/overview.asp
+++ b/tests/fixtures/huawei/overview.asp
@@ -1,0 +1,1613 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
+<meta http-equiv="X-UA-Compatible" content="IE=edge;chrome=1"/>
+<link rel="stylesheet" type="text/css" href="/Cuscss/frame.css?03fa5651e1972f63229090335" />
+<link rel="stylesheet" type="text/css" href="/Cuscss/overview.css?03fa5651e1972f63229090335" />
+<script language="javascript" src="/resource/common/jquery.min.js?03fa5651e1972f63229090335"></script>
+<script language="javascript" src="/resource/common/util.js?03fa5651e1972f63229090335"></script>
+<script language="JavaScript" src="/Cusjs/ptvdfjs.js?03fa5651e1972f63229090335"></script>
+<script language="JavaScript" src="/frameaspdes/portuguese/ssmpdes.js?03fa5651e1972f63229090335"></script>
+<script language="javascript" src="/html/amp/common/wlan_list.asp"></script>
+<script language="JavaScript" src="../../../Cusjs/ptvdfjs.js?03fa5651e1972f63229090335"></script>
+<script language="JavaScript" type="text/javascript">
+
+var curUserType = '1';
+var CfgMode = 'PTVDF2WIFI_PWD';
+var UserDevices = new Array();
+var para = '';
+var devtype = '';
+var menulist = [];
+var activeMenuId = null;
+var wifiDev = new Array();
+var wifiDevOnline = new Array();
+var wifiDevOffline = new Array();
+var guestwifiDevOnline = new Array();
+var guestwifiDevOffline = new Array();
+var wifiDevNumOnline = 0;
+var wifiDevNumOffline = 0;
+var guestwifiDevNumOnline = 0;
+var guestwifiDevNumOffline = 0;
+var wlanStaBoostCount2g = 0;
+var wlanStaBoostCount5g = 0;
+var boostAddId;
+var editNetWorkDomain;
+var editNetWorkNum;
+var selectImgIndex;
+var GroupNameFirst;
+var ethNumOnline = 0;
+var imgInfo = ["../images/game.png", "../images/landline-phone.png", "../images/laptop.png", "../images/playstation.png", "../images/printer.png",
+               "../images/smartphone.png", "../images/tablet.png", "../images/tv.png", "../images/tv-center-center-2000.png", "../images/vox.png"]
+var activeImgInfo = ["../images/game_active.png", "../images/landline-phone_active.png", "../images/laptop_active.png", "../images/playstation_active.png", "../images/printer_active.png",
+               "../images/smartphone_active.png", "../images/tablet_active.png", "../images/tv_active.png", "../images/tv-center-center-2000_active.png", "../images/vox_active.png"]
+function stDftPrinter(domain, PrinterEnable, PrinterName) {
+    this.domain = domain;
+    this.PrinterEnable = PrinterEnable;
+    this.PrinterName = PrinterName;
+}
+var dftPrinters = new Array(new stDftPrinter("InternetGatewayDevice.Services.X_HW_Printer","0",""),null);
+var dftPrinter = dftPrinters[0];
+var SMBEnable = '0';
+
+var WlanInfo = new Array();
+WlanInfo = new Array(new stWlan("InternetGatewayDevice\x2eLANDevice\x2e1\x2eWLANConfiguration\x2e1","1","ath0","TestSSID"),new stWlan("InternetGatewayDevice\x2eLANDevice\x2e1\x2eWLANConfiguration\x2e2","0","ath1","TestSSID\x2dGuest"),new stWlan("InternetGatewayDevice\x2eLANDevice\x2e1\x2eWLANConfiguration\x2e3","0","ath2","TestSSID\x5fWiFi7"),new stWlan("InternetGatewayDevice\x2eLANDevice\x2e1\x2eWLANConfiguration\x2e4","0","ath6","TestSSID\x5fWiFi7"),new stWlan("InternetGatewayDevice\x2eLANDevice\x2e1\x2eWLANConfiguration\x2e5","1","ath4","TestSSID"),new stWlan("InternetGatewayDevice\x2eLANDevice\x2e1\x2eWLANConfiguration\x2e6","0","ath5","TestSSID\x2dGuest"),null);
+var AttachConfs = new Array(new stAttachConf("InternetGatewayDevice\x2eLANDevice\x2e1\x2eWLANConfiguration\x2e1\x2eX\x5fHW\x5fAttachConf","0"),new stAttachConf("InternetGatewayDevice\x2eLANDevice\x2e1\x2eWLANConfiguration\x2e2\x2eX\x5fHW\x5fAttachConf","0"),new stAttachConf("InternetGatewayDevice\x2eLANDevice\x2e1\x2eWLANConfiguration\x2e3\x2eX\x5fHW\x5fAttachConf","0"),new stAttachConf("InternetGatewayDevice\x2eLANDevice\x2e1\x2eWLANConfiguration\x2e4\x2eX\x5fHW\x5fAttachConf","0"),new stAttachConf("InternetGatewayDevice\x2eLANDevice\x2e1\x2eWLANConfiguration\x2e5\x2eX\x5fHW\x5fAttachConf","0"),new stAttachConf("InternetGatewayDevice\x2eLANDevice\x2e1\x2eWLANConfiguration\x2e6\x2eX\x5fHW\x5fAttachConf","0"),null); 
+var wlanStaBoostList = new Array(null);
+
+var productName = 'HG8247B7\x2d8N'.toUpperCase();
+
+var UserDhcpInfo;
+var UserDevInfo;
+
+var token="0303030303030303030303030303030303030303030303030303030303030303"
+$.ajax({
+    type : "POST",
+    async : false,
+    cache : false,
+    url : "userDevSendArp.cgi?RequestFile=overview.asp",
+    data: 'x.X_HW_Token=' + token,
+    success : function(data) {
+    }
+});
+
+function GetOldLanUserDevInfo(func) {
+    $.ajax({
+        type : "POST",
+        async : false,
+        cache : false,
+        url : "/html/bbsp/common/getLanUserDevInfo_ptvdf.asp",
+        success : function(data) {
+            UserDevInfo = dealDataWithFun(data);
+            if (func) {
+                func(UserDevInfo);
+            }
+        }
+    });
+}
+
+function GetLanUserDevInfo(func) {
+    setTimeout(function() {
+        GetOldLanUserDevInfo(func);
+    }, 1000);
+}
+
+function stWlan(domain,enable,name,ssid) {
+    this.domain = domain;
+    this.enable = enable;
+    this.name = name;
+    this.ssid = ssid;
+}
+function USERDeviceInfo(Domain,IpAddr,MacAddr,PortID,DevType,DevStatus,PortType,HostName,DeviceType,UserDevAlias,LeaseTimeRemaining,GroupName,Time) {
+    this.Domain 	= Domain;
+    this.IpAddr	    = (IpAddr.length == 0)?"--":IpAddr;
+    this.MacAddr	= MacAddr;
+    this.PortID = PortID; 
+    this.DevType	= DevType;
+    this.DevStatus 	= DevStatus;
+    this.PortType	= PortType;
+    this.HostName	= HostName;
+    this.DeviceType = DeviceType;
+    this.UserDevAlias = UserDevAlias;
+    this.LeaseTimeRemaining = LeaseTimeRemaining;
+    if(GroupName=="") {
+        this.GroupName = "0;0";
+    }else{
+        this.GroupName = GroupName;
+    }
+    this.Time	= Time;
+}
+var g_AllUserDevinfo = new Array(new USERDeviceInfo("InternetGatewayDevice.LANDevice.1.X_HW_UserDev.1","192\x2e168\x2e1\x2e11","02\x3a00\x3a00\x3a00\x3a00\x3a01","LAN1","\x2d\x2d","Online","ETH","","0","","0","","0\x3a14"),new USERDeviceInfo("InternetGatewayDevice.LANDevice.1.X_HW_UserDev.2","192\x2e168\x2e1\x2e37","02\x3a00\x3a00\x3a00\x3a00\x3a02","SSID1","\x2d\x2d","Offline","WIFI","","0","","0","","28\x3a4"),new USERDeviceInfo("InternetGatewayDevice.LANDevice.1.X_HW_UserDev.3","192\x2e168\x2e1\x2e1","02\x3a00\x3a00\x3a00\x3a00\x3a03","LAN1","\x2d\x2d","Online","ETH","","0","","0","","4\x3a52"),new USERDeviceInfo("InternetGatewayDevice.LANDevice.1.X_HW_UserDev.4","192\x2e168\x2e1\x2e31","02\x3a00\x3a00\x3a00\x3a00\x3a04","LAN1","\x2d\x2d","Offline","ETH","","0","","0","","0\x3a6"),new USERDeviceInfo("InternetGatewayDevice.LANDevice.1.X_HW_UserDev.5","0\x2e0\x2e0\x2e0","02\x3a00\x3a00\x3a00\x3a00\x3a05","SSID1","","Offline","WIFI","","0","","0","","29\x3a14"),new USERDeviceInfo("InternetGatewayDevice.LANDevice.1.X_HW_UserDev.6","192\x2e168\x2e1\x2e84","02\x3a00\x3a00\x3a00\x3a00\x3a06","LAN1","\x2d\x2d","Offline","ETH","","0","","0","","0\x3a6"),null);
+var allUserDevinfo = truncate(g_AllUserDevinfo)
+var onLineDev = [];
+for (let index = 0; index < allUserDevinfo.length; index++) {
+    if(allUserDevinfo[index].DevStatus.toUpperCase() == "ONLINE" && allUserDevinfo[index].PortType.toUpperCase() == "ETH") {
+        onLineDev.push(allUserDevinfo[index]);
+    }
+}
+function stPhysicalMedium(domain, Name, Status, X_HW_SafeRemove) {
+    this.domain = domain;
+    this.Name = Name;
+    this.Status = Status;
+    this.X_HW_SafeRemove = X_HW_SafeRemove;
+}
+var usblist = new Array(null)
+function stWlanStaBoost(domain, ChipIndex, MACAddress, Duration, DurationTime) {
+    this.domain = domain;
+    this.ChipIndex = ChipIndex;
+    this.MACAddress = MACAddress.toUpperCase();
+    this.Duration = Duration;
+    this.DurationTime = DurationTime;
+    this.StaOnlineStu = 0;
+}
+
+function stAttachConf(domain,X_HW_AirtimeFairness) {
+    this.domain = domain;
+    this.X_HW_AirtimeFairness = X_HW_AirtimeFairness;
+}
+
+var AttachConf2g = new stAttachConf('0', '0');
+var AttachConf5g = new stAttachConf('0', '0');
+var wlanStaBoostMap = new Array();
+
+for (i=0; i < WlanInfo.length-1; i++) {
+    if (getWlanPortNumber(WlanInfo[i].name) >= SsidPerBand) {    
+        AttachConf5g = AttachConfs[i];
+    }
+
+    if (getWlanPortNumber(WlanInfo[i].name) < SsidPerBand) {
+        AttachConf2g = AttachConfs[i];
+    }
+}
+
+for (var i=0; i < wlanStaBoostList.length-1; i++) {
+    wlanStaBoostMap[wlanStaBoostList[i].MACAddress.toUpperCase()] = wlanStaBoostList[i];
+    if (wlanStaBoostList[i].ChipIndex == 0) {
+        wlanStaBoostCount2g++;
+    } else if (wlanStaBoostList[i].ChipIndex == 1) {
+        wlanStaBoostCount5g++;
+    }
+
+    if (wlanStaBoostList[i].Duration != 0) {
+        wlanStaBoostList[i].StaOnlineStu = wlanStaBoostList[i].Duration * 3600 - wlanStaBoostList[i].DurationTime;
+    }
+}
+
+function SetStaBoostTime() {
+    var isUptime = 0;
+    for (var i = 0; i < wlanStaBoostList.length-1; i++) {
+        if (wlanStaBoostList[i].Duration != 0) {
+            wlanStaBoostList[i].StaOnlineStu = wlanStaBoostList[i].StaOnlineStu - 1;
+        }
+        if (wlanStaBoostList[i].StaOnlineStu > 0) {
+            isUptime = isUptime + 1;
+        }
+    }
+
+    if (isUptime == 0) {
+        clearInterval(showStaBoostTime);
+        return;
+    }
+}
+
+function checkAddStaBoost(freq) {
+    var AttachConf = AttachConf2g;
+    if (freq == "5G") {
+        AttachConf = AttachConf5g;
+    }
+
+    if (AttachConf.X_HW_AirtimeFairness != 1) {
+        alertVDF(framewifiinfo["framewifi002"]);
+        return false;
+    }
+
+    if (((wlanStaBoostCount5g >= 2) && (freq == "5G")) || ((wlanStaBoostCount2g >= 2) && (freq == "2G"))) {
+        alertVDF(framewifiinfo["framewifi003"]);
+        return false;
+    }
+
+    return true;
+}
+
+function USERDevice(Domain,IpAddr,MacAddr,Port,IpType,DevType,DevStatus,PortType,Time,HostName,GroupName) {
+    this.Domain     = Domain;
+    this.IpAddr     = IpAddr;
+    this.MacAddr    = MacAddr;
+    this.Port       = Port;
+    this.PortType   = PortType;
+    this.DevStatus  = DevStatus;
+    this.IpType     = IpType;
+    if (IpType=="Static"){
+        this.DevType="--";
+    } else {
+        if(DevType=="") {
+            this.DevType    = "--"; 
+        } else {
+            this.DevType    = DevType;      
+        }   
+    }
+    this.Time = Time;
+    
+    if (HostName=="") {
+        this.HostName   = "--";
+    } else {
+       this.HostName    = HostName;
+    }
+    if(GroupName==""){
+        this.GroupName = "0;0";
+    }else{
+        this.GroupName = GroupName;
+    }
+}
+
+if (window.location.href.indexOf("type") != -1) {
+    para = window.location.href.split("type")[1]; 
+    devtype = para.split("=")[1];
+}
+
+var associatedDevice = new Array(new stAssociatedDevice("InternetGatewayDevice\x2eLANDevice\x2e1\x2eWLANConfiguration\x2e1\x2eAssociatedDevice\x2e1","02\x3a00\x3a00\x3a00\x3a00\x3a07","\x2d73"),new stAssociatedDevice("InternetGatewayDevice\x2eLANDevice\x2e1\x2eWLANConfiguration\x2e1\x2eAssociatedDevice\x2e2","02\x3a00\x3a00\x3a00\x3a00\x3a08","\x2d55"),new stAssociatedDevice("InternetGatewayDevice\x2eLANDevice\x2e1\x2eWLANConfiguration\x2e1\x2eAssociatedDevice\x2e3","02\x3a00\x3a00\x3a00\x3a00\x3a09","\x2d46"),new stAssociatedDevice("InternetGatewayDevice\x2eLANDevice\x2e1\x2eWLANConfiguration\x2e1\x2eAssociatedDevice\x2e4","02\x3a00\x3a00\x3a00\x3a00\x3a05","\x2d34"),new stAssociatedDevice("InternetGatewayDevice\x2eLANDevice\x2e1\x2eWLANConfiguration\x2e5\x2eAssociatedDevice\x2e1","02\x3a00\x3a00\x3a00\x3a00\x3a0a","\x2d84"),new stAssociatedDevice("InternetGatewayDevice\x2eLANDevice\x2e1\x2eWLANConfiguration\x2e5\x2eAssociatedDevice\x2e2","02\x3a00\x3a00\x3a00\x3a00\x3a0b","\x2d80"),new stAssociatedDevice("InternetGatewayDevice\x2eLANDevice\x2e1\x2eWLANConfiguration\x2e5\x2eAssociatedDevice\x2e3","02\x3a00\x3a00\x3a00\x3a00\x3a0c","\x2d68"),new stAssociatedDevice("InternetGatewayDevice\x2eLANDevice\x2e1\x2eWLANConfiguration\x2e5\x2eAssociatedDevice\x2e4","02\x3a00\x3a00\x3a00\x3a00\x3a0d","\x2d72"),null);
+
+function stAssociatedDevice(domain, AssociatedDeviceMACAddress, X_HW_RSSI) {
+    this.domain = domain;
+    this.AssociatedDeviceMACAddress = AssociatedDeviceMACAddress;
+    this.X_HW_RSSI = X_HW_RSSI;
+}
+
+var showStaBoostTime;
+$(document).ready( function() {
+    var $submenu = $('.submenu');
+    var $mainmenu = $('.container');
+    $submenu.hide();
+
+    $(".container .li2").on('click', function() {
+        if ($(this).find('.icon2').hasClass('rotate')) {
+            $(this).find('.icon2').removeClass("rotate");
+            $(this).find('.icon2').addClass("rotate1");
+        } else {
+            $(this).find('.icon2').removeClass("rotate1");
+            $(this).find('.icon2').addClass("rotate");
+        }
+        $(this).next('.submenu').slideToggle().siblings('.submenu').slideUp();
+    });
+    showStaBoostTime = setInterval("SetStaBoostTime()",1000);
+});
+var newLastList = [];
+var onLineDevList = [];
+GetLanUserDevInfo(function(para) {
+    UserDevices = para;
+
+    let offLineDevList = [];
+    for (let k = 0; k < allUserDevinfo.length; k++) {
+        if (allUserDevinfo[k].GroupName == '0;0') {
+            allUserDevinfo[k].GroupName = '7;7'
+            if (allUserDevinfo[k].PortType.toUpperCase() == "WIFI") {
+                allUserDevinfo[k].GroupName = '7;5'
+            }
+        }
+        if (allUserDevinfo[k].PortType.toUpperCase() == "ETH") {
+            if (allUserDevinfo[k].DevStatus.toUpperCase() == "ONLINE") {
+                onLineDevList.push(allUserDevinfo[k]);
+            } else {
+                offLineDevList.push(allUserDevinfo[k]);
+            }
+        }
+    }
+    var allUserDevList = onLineDevList.concat(offLineDevList);
+
+    if (allUserDevList.length <= 3) {
+        GetDevInfo(allUserDevList);
+    } else {
+        var newFirstList = allUserDevList.slice(0,3);
+        newLastList =  allUserDevList.slice(3)
+        GetDevInfo(newFirstList);
+        showMoreNetDev();
+        
+    } 
+
+    GetWifiDevInfo();
+    if ('LINEDEV' == devtype.toUpperCase()) {
+        ShowCntDevDetails(devtype, EthDev);
+    }
+});
+
+function RedirectToPhone() {
+    window.parent.onFirstMenuChange("PhoneID", "CallLogID");
+}
+
+function RedirectToPhoneSche() {
+    window.parent.onFirstMenuChange("PhoneID", "RingingScheduleID");
+}
+
+function RedirectToVoiceState() {
+    window.parent.onFirstMenuChange("StatusSupportId", "StatusId");
+    window.parent.onThirdMenuChange("VoiceStatusID");
+}
+
+function RedirectToWifiSche() {
+    window.parent.onFirstMenuChange("Wi-FiID", "PowerSavingModeID");
+}
+
+function RedirectToWifiGeneral() {
+    window.parent.onFirstMenuChange("Wi-FiID", "GeneralID");
+}
+
+function RedirectToWifiWps() {
+    window.parent.onFirstMenuChange("Wi-FiID", "WPSID");
+}
+function RedirectToNetwork() {
+    window.parent.onFirstMenuChange("SettingsID", "LANIPv4ID");
+}
+
+function RedirectToUSB() {
+    window.parent.onFirstMenuChange("SettingsID","USBID");
+}
+
+function intoPrint() {
+    window.parent.onFirstMenuChange("SettingsID","PrinterSharingID");
+}
+function USERDeviceV6(Domain,IP,Scope,HostName,DevType,MacAddr,DevStatus,PortType,PortID) {
+    this.Domain     = Domain;
+    this.IP         = IP;
+    this.Scope      = Scope;
+    this.HostName       = HostName;
+    this.DevType        = DevType;
+    this.MacAddr        = MacAddr;
+    this.DevStatus      = DevStatus;
+    this.PortType       = PortType;
+    this.PortID     = PortID;
+}
+var UserDevIpv6Info = new Array(new USERDeviceV6("InternetGatewayDevice.LANDevice.1.X_HW_UserDev.5.IPv6Address.1","fe80\x3a\x3ae56b\x3a3e94\x3a737b\x3a46df","LLA","","\x2d\x2d","02\x3a00\x3a00\x3a00\x3a00\x3a05","Online","WIFI","SSID1"),null);
+function UserDevFindIpv6(domain) {
+    var ipaddr_gua = "";
+
+    var usrdevid = domain.split(".")[4];
+
+    for(var i = 0; i < UserDevIpv6Info.length - 1; i++)
+    {
+        var usrdev6id = UserDevIpv6Info[i].Domain.split(".")[4];
+
+        if((usrdevid == usrdev6id)&&(UserDevIpv6Info[i].Scope == "GUA") && (UserDevIpv6Info[i].DevStatus.toUpperCase() == "ONLINE"))
+        {
+            ipaddr_gua = UserDevIpv6Info[i].IP;
+            break;
+        }
+    }
+    return ipaddr_gua;
+}
+
+function GetConnectTime(userDev) {
+    let LanTime = userDev.Time.split(":")
+    let day = 0;
+    let hour = LanTime[0];
+    if (LanTime[0] >= 24) {
+        day = parseInt(LanTime[0]/24);
+        hour = LanTime[0]%24;
+    }
+
+    let min = LanTime[1];
+    var connecttime = " " + day + "d " + hour + "h " + min + "mins";
+    if (userDev.DevStatus.toUpperCase() != "ONLINE") {
+        connecttime = "--";
+    }
+
+    return connecttime;
+}
+
+function GetDevInfo(allUserDevList) {
+
+    for (let j = 0; j < allUserDevList.length; j++) {
+        allUserDevList[j].arryIndex = j
+    }
+
+    ethNumOnline = allUserDevList.length;
+
+    for(var i = 0; i < allUserDevList.length; i++) {
+        var devName;
+        if (allUserDevList[i].UserDevAlias == "") {
+            devName = allUserDevList[i].HostName;
+        } else {
+            devName = allUserDevList[i].UserDevAlias;
+        }
+        if (devName == "") {
+            devName = "--";
+        }
+        GroupNameFirst = allUserDevList[i].GroupName.split(";")[0];
+        var port = allUserDevList[i].PortID.replace("LAN","");
+
+        var unit_h = (parseInt(allUserDevList[i].Time.split(":")[0],10) > 1) ? " hours" : " hour";
+        var unit_m = (parseInt(allUserDevList[i].Time.split(":")[1],10) > 1) ? " minutes" : " minute";
+
+        document.getElementById("network").innerHTML += '<li class="li2" id="networkLi_'+ i + '">'
+        + '<img src="'+ imgInfo[allUserDevList[i].GroupName.split(";")[1]] + '" class="icon">'
+        + '<span title=" ' + escapeHTML(devName) + ' ">' + escapeHTML(restrictingLength(devName,10))  + '</span>'
+        + '<i><img src="../images/arrow-down.png" class="icon2" id = "iconTop" ></i>'
+        + '<i><img src="../images/arrow-up.png" class="icon2 " id ="iconBottm" style ="display:none"></i>'
+        + '</li>'
+        + '<ul class="submenu" style="display:none;">'
+        + '<li><i><img src="../images/button-info-desktop.png" onClick="showEthDetailInfo(this.id, false)" id="' +allUserDevList[i].Domain + "-"+ allUserDevList[i].arryIndex + '"></i></li>'
+        + '<li><i><img src="../images/button-edit-desktop.png" onClick="showEditbox(this.id)" id="' + allUserDevList[i].Domain + "-"+ allUserDevList[i].GroupName.split(";")[1] + '"></i></li>'
+        + '<div class="detailInfo" id="detailInfo_' + i +'">'
+        + '<div id="trangle"></div>'
+        + '<div class="infobox">' + framedesinfo["frame034"] + escapeHTML(devName) + '</div>'
+        + '<div class="infobox">IPv4:' + allUserDevList[i].IpAddr + '</div>'
+        + '<div class="infobox">IPv6:' + UserDevFindIpv6(allUserDevList[i].Domain) + '</div>'
+        + '<div class="infobox">' + framedesinfo["frame033"] + allUserDevList[i].MacAddr.toUpperCase() + '</div>'
+        + '<div class="infobox">'+ framedesinfo["frame035"] + GetConnectTime(allUserDevList[i]) + '</div>'
+        + '<div class="infobox">LAN:' + port + '</div>'
+        + '</div>'
+        + '</ul>'
+            $('#network .li2').on('click',function(){
+            if ($(this).next('.submenu').is(':hidden')) {
+
+                 $(this).find('#iconTop')[0].style.display = 'none';
+                 $(this).find('#iconBottm')[0].style.display = 'block';
+
+
+
+
+            } else {
+                $(this).find('#iconTop')[0].style.display = 'block';
+                $(this).find('#iconBottm')[0].style.display = 'none';
+            }
+            $(this).next('.submenu').slideToggle();
+            })
+        if (allUserDevList[i].DevStatus == "Offline") {
+            $("#networkLi_" + i).addClass("op40");
+            $("#networkLi_" + i).find('#iconTop')[0].style.display = 'none';
+            $("#networkLi_" + i).find('#iconBottm')[0].style.display = 'none';
+        }
+    }       
+}
+
+function showMoreNetDev() {
+    var titileHtml = framewifiinfo["framewifi005"] + newLastList.length +  framewifiinfo["framewifi006"] 
+    var html = '<ul id="showNetWork" class="container" onClick="showNetWork(this,event);">' +
+        '<li class="li2" style="padding:0 0 0 15px;">' +
+        '<span id = "shoeMoreSpan">' +
+        '<span style="display: inline;" id="shoeMore" title = "'+ titileHtml +'" >' + restrictingLength(titileHtml,20) + '</span>' +
+        '</span>' +
+        '<span style="display:none;" id="hideMoreSpan" title = "'+ framewifiinfo["framewifi007"] +'">' + restrictingLength(framewifiinfo["framewifi007"],20) + '</span>' +
+        '<i><img src="../images/arrow-down.png" id = "downPic" class="icon2" ></i>' +
+        '<i><img src="../images/arrow-up.png" id = "upPic" class="icon2" style = "display:none"></i>' +
+        '</li>' +
+        '</ul>';
+    $("#network").append(html);
+    var moreHtml = '<div id = "moreHtml" class = "container" style = "display: none"></div>'
+    $("#network").append(moreHtml);
+    for (var i = 0; i < newLastList.length; i++) {
+        var devName = '';
+        if (newLastList[i].UserDevAlias == "") {
+            devName = newLastList[i].HostName;
+        } else {
+            devName = newLastList[i].UserDevAlias;
+        }
+        if (devName == "") {
+            devName = "--";
+        }
+        let childHtml = '<li margin-left: 16px; class="li2"  id="networkMore_'+ i + '">'
+        + '<img src="'+ imgInfo[newLastList[i].GroupName.split(";")[1]] + '" class="icon">'
+        + '<span>' + escapeHTML(restrictingLength(devName, 10)) + '</span>'
+        + '<i><img src="../images/arrow-down.png" class="icon2" id = "iconTop" ></i>'
+        + '<i><img src="../images/arrow-up.png" class="icon2 " id ="iconBottm" style ="display:none"></i>'
+        + '</li>'
+        + '<ul class="submenu" style="display:none;">'
+        + '<li><i><img src="../images/button-info-desktop.png" onClick="showEthDetailInfo(this.id, true)" id="' + newLastList[i].Domain + "-"+ i + '"></i></li>'
+        + '<li><i><img src="../images/button-edit-desktop.png" onClick="showEditbox(this.id)" id="' + newLastList[i].Domain + "-"+ newLastList[i].GroupName.split(";")[1] + '"></i></li>'
+        + '<div class="detailInfo" id="moreDetailInfo_' + i +'">'
+        + '<div id="trangle"></div>'
+        + '<div class="infobox">' + framedesinfo["frame034"] + escapeHTML(devName) + '</div>'
+        + '<div class="infobox">IPv4:' + newLastList[i].IpAddr + '</div>'
+        + '<div class="infobox">IPv6:' + UserDevFindIpv6(newLastList[i].Domain) + '</div>'
+        + '<div class="infobox">' + framedesinfo["frame033"] + newLastList[i].MacAddr.toUpperCase() + '</div>'
+        + '<div class="infobox">'+ framedesinfo["frame035"] + GetConnectTime(newLastList[i]) + '</div>'
+        + '<div class="infobox">LAN:' + newLastList[i].PortID.replace("LAN","") + '</div>'
+        + '</div>'
+        + '</ul>'
+        $("#moreHtml").append(childHtml);
+        if (newLastList[i].DevStatus == "Offline") {
+            $("#networkMore_" + i).addClass("op40");
+            $("#networkMore_" + i).find('#iconTop')[0].style.display = 'none';
+            $("#networkMore_" + i).find('#iconBottm')[0].style.display = 'none';
+        }
+    }
+
+    $('#moreHtml .li2').on('click',function() {
+        if ($(this).next('.submenu').is(':hidden')) {
+            $(this).find('#iconTop')[0].style.display = 'none';
+            $(this).find('#iconBottm')[0].style.display = 'block';
+        } else {
+            $(this).find('#iconTop')[0].style.display = 'block';
+            $(this).find('#iconBottm')[0].style.display = 'none';
+        }
+
+        $(this).next('.submenu').slideToggle();
+    })
+}
+
+function showNetWork(obj,event) {
+    if ($("#moreHtml")[0].style.display == 'block') {
+        $("#downPic")[0].style.display = 'block'
+        $("#upPic")[0].style.display = 'none';
+        setDisplay("moreHtml",0);
+        setDisplay("hideMoreSpan",0);
+        setDisplay("shoeMoreSpan",1);
+    } else {
+        setDisplay("moreHtml",1);
+        $("#downPic")[0].style.display = 'none'
+        $("#upPic")[0].style.display = 'block';
+        setDisplay("hideMoreSpan",1);
+        setDisplay("shoeMoreSpan",0);
+    }
+}
+
+
+var isUpFlag = true;
+function ShowNetworkDevice(id) {
+    if (isUpFlag) {
+        $("#showDevNum").css("display","none")
+        $("#hideDevNum").css("display","block")
+        isUpFlag = false;
+    } else {
+        $("#showDevNum").css("display","block")
+        $("#hideDevNum").css("display","none")
+        isUpFlag = true;
+    }
+}
+
+function InitWifiDevOnline(wifiDev, i, isGuest) {
+    var time = wifiDev.Time.split(":");
+    var day = 0;
+    var hour = time[0];
+    var min = time[1];
+    if (time[0] >= 24) {
+        day = parseInt(time[0]/24);
+        hour = time[0]%24;
+    }
+    var connecttime = " " + day + "d " + hour + "h " + min + "mins";
+    if (wifiDev.Time == "") {
+        connecttime = "--";
+    }
+    var Port = wifiDev.Port;
+    var freq = "2.4GHz";
+    if (Port == "SSID1" || Port == "SSID2") {
+        freq = "2.4GHz";
+    } else if (['SSID3', 'SSID5', 'SSID6'].indexOf(Port) !== -1) {
+        freq = "5GHz";
+    }
+    
+    var Rssi = GetAssociateInfoByMac(wifiDev.MacAddr);
+    var signalRssi = (Rssi == 0) ? 0 : Rssi.X_HW_RSSI;
+    if (signalRssi < -80) {
+        var imgSrc = "signal_empty.png";
+    } else if ((signalRssi >= -80 ) && (signalRssi <= -75)) {
+        var imgSrc = "signal_1from4.png";
+    } else if ((signalRssi > -75 )&&(signalRssi <= -69 )) {
+        var imgSrc = "signal_2from4.png";
+    } else if ((signalRssi > -69 )&&(signalRssi <= -63 )) {
+        var imgSrc = "signal_3from4.png";
+    } else if (signalRssi > -63 ) {
+        var imgSrc = "signal_full.png";
+    }
+
+    var allUserDevive = new Array();
+    for(var k = 0; k < allUserDevinfo.length; k++) {
+        if (wifiDev.MacAddr.toUpperCase() == allUserDevinfo[k].MacAddr.toUpperCase()) {
+            allUserDevive = allUserDevinfo[k];
+        }
+    }
+
+    var showName = (wifiDev.UserDevAlias == "") ? wifiDev.HostName : wifiDev.UserDevAlias;
+
+    var html = '<li class="li2" id="' + isGuest + 'wifiLi_'+ i + '" onClick="ShowWifiPic(this);">'
+    + '<div><img src="' + imgInfo[allUserDevive.GroupName.split(";")[1]] + '" class="icon"></div>'
+    + '<div class="wifiStaName" title="' + escapeHTML(showName) + '">' + escapeHTML(restrictingLength(showName, 11)) + '</div>'
+    + '<div><img id="' + isGuest + 'wifiSignal_'+ i + '" src="../images/' + imgSrc + '" class="strengthIcon"></div>'
+    + '<div id="' + isGuest + 'wifiBoost_'+ i + '" style="display:none;"><img src="../images/boost_error_icon.png" class="strengthIcon"></div>'
+    + '<i><img src="../images/arrow-down.png" class="icon2"></i>'
+    + '</li>'
+    + '<ul id="' + isGuest + 'clickShow_' + i + '" class="submenu" style="display:none;">'
+    + '<li><i><img src="../images/button-info-desktop.png" onClick="showWifiDetailInfo(this.id)" id="detail' + isGuest + 'img_'+ i + '"></i></li>'
+    + '<li><i><img src="../images/button-edit-desktop.png" onClick="showEditbox(this.id)" id="' + allUserDevive.Domain + "-" + allUserDevive.GroupName.split(";")[1] + '"></i></li>'
+    + '<li><i><img src="../images/boosting_wifi.png" onClick="showWifiBoost(this.id)" id="' + isGuest + 'boostimg_'+ i + '">'
+    +'<img style="display:none;" src="../images/boost_error_icon.png" onClick="DelWifiBoost(this.id)" id="' + isGuest + 'Delboostimg_'+ i + '"></i></li>'
+    + '<div id="' + isGuest + 'boostTime_'+ i + '" style="margin-left:80px;display:none;"></div>'
+    + '<div class="detailInfo" style="padding-left: 20px;" id="' + isGuest + 'wifidetailInfo_' + i +'">'
+    + '<div id="trangle"></div>'
+    + '<div class="infobox">Name:' + escapeHTML(showName) + ' (' + freq + ')' + '</div>'
+    + '<div class="infobox">IPv4:' + wifiDev.IpAddr + '</div>'
+    + '<div class="infobox">IPv6:' + UserDevFindIpv6(wifiDev.Domain) + '</div>'
+    + '<div class="infobox">MAC Address:<span id="' + isGuest + 'OnlineMac'+ i + '">' + wifiDev.MacAddr.toUpperCase() + '</span></div>'
+    + '<div class="infobox">Connection duration:' + connecttime + '</div>'
+    + '</div>'
+    + '</ul>'
+    $("#" + isGuest + "wifiContent").append(html);
+    if (i >= 3 && (isGuest == "")) {
+        document.getElementById("wifiLi_" + i).style.display="none";
+        $("clickShow_"+ i).addClass("wifihide");
+    } else if (isGuest == "guest") {
+        document.getElementById(isGuest + "wifiLi_" + i).style.display="none";
+    }
+    
+    if (CheckMacInBoost(wifiDev.MacAddr)) {
+        document.getElementById(isGuest + "wifiBoost_" + i).style.display="";
+    }
+}
+
+function InitWifiDevOffline(wifiDev, i, isGuest) {
+    var allUserDevive = new Array();
+    for(var k = 0; k < allUserDevinfo.length; k++) {
+        if (wifiDev.MacAddr.toUpperCase() == allUserDevinfo[k].MacAddr.toUpperCase()) {
+            allUserDevive = allUserDevinfo[k];
+        }
+    }
+
+    var showName = (wifiDev.UserDevAlias == "") ? wifiDev.HostName : wifiDev.UserDevAlias;
+    var html = '<li class="li2 op40" id="' + isGuest + 'wifiLi_'+ i + '" title="' + escapeHTML(showName) + '">'
+            + '<img src="' + imgInfo[allUserDevive.GroupName.split(";")[1]] + '" class="icon">'
+            + '<span>' + escapeHTML(restrictingLength(showName, 11)) + '</span>'
+            + '</li>'
+            $("#" + isGuest + "wifiContent").append(html);
+
+    if (i >= 3 && (isGuest == "")) {
+        document.getElementById("wifiLi_" + i).style.display="none";
+    } else if (isGuest == "guest") {
+        document.getElementById(isGuest + "wifiLi_" + i).style.display="none";
+    }
+}
+
+function ShowMoreDevice(id,num) {
+    var html = '<ul id="ShowwifiDeviceUl" class="container" title="' + framewifiinfo["framewifi005"] + num + framewifiinfo["framewifi006"] + '" onClick="ShowwifiDevice(this.id);">' +
+        '<li class="li2" style="padding:0 0 0 15px;overflow: hidden;text-overflow: ellipsis;white-space: nowrap;padding-right:20px;">' +
+        '<span style="display: inline;margin-left: -3px;" id="showDeviceSpan">' + framewifiinfo["framewifi005"] + '</span>' +
+        '<span style="display: inline;" id="hideWifiNumSpan">' + num + '</span>' +
+        '<span style="display: inline;" id="showDeviceSpanLast">' + framewifiinfo["framewifi006"] + '</span>' +
+        '<span style="display:none;" id="hideDeviceSpan">' + framewifiinfo["framewifi007"] + '</span>' +
+        '<i><img src="../images/arrow-down.png" class="icon2"></i>' +
+        '</li>' +
+        '</ul>';
+    $("#" + id).append(html);
+}
+
+function ChangeTitleById(id) {
+    var text = document.getElementById(id).innerText;
+    document.getElementById(id).title = text;
+}
+
+function ShowwifiDevice(id) {
+    var isGuest = (id.indexOf("guest") != -1) ? "guest" : "";
+    var deviceNum = (isGuest == "guest") ? (guestwifiDevNumOnline + guestwifiDevNumOffline) : (wifiDevNumOnline + wifiDevNumOffline);
+    var value = document.getElementById(isGuest + "hideDeviceSpan").style.display;
+    var isHide = "";
+
+    if (value == "none") {
+        document.getElementById(isGuest + "hideDeviceSpan").style.display = "inline";
+        document.getElementById(isGuest + "showDeviceSpan").style.display = "none";
+        document.getElementById(isGuest + "hideWifiNumSpan").style.display = "none";
+        document.getElementById(isGuest + "showDeviceSpanLast").style.display = "none";
+        isHide = "";
+    } else {
+        document.getElementById(isGuest + "hideDeviceSpan").style.display = "none";
+        document.getElementById(isGuest + "showDeviceSpan").style.display = "inline";
+        document.getElementById(isGuest + "hideWifiNumSpan").style.display = "inline";
+        document.getElementById(isGuest + "showDeviceSpanLast").style.display = "inline";
+        isHide = "none";
+    }
+    ChangeTitleById(isGuest + "ShowwifiDeviceUl");
+    $(".wifihide").css("display", isHide);
+
+    for (var i = 0;i < deviceNum; i++) {
+        if (i >= 3 && isGuest == "") {
+            document.getElementById("wifiLi_" + i).style.display = isHide;
+        } else if (isGuest == "guest") {
+            document.getElementById(isGuest + "wifiLi_" + i).style.display = isHide;
+        }
+    }
+
+    if (isGuest == "") {
+        if ($('#ShowwifiDeviceUl .icon2').hasClass('rotate')) {
+            $('#ShowwifiDeviceUl .icon2').removeClass("rotate");
+            $('#ShowwifiDeviceUl .icon2').addClass("rotate1");
+        } else {
+            $('#ShowwifiDeviceUl .icon2').removeClass("rotate1");
+            $('#ShowwifiDeviceUl .icon2').addClass("rotate");
+        }
+    }
+}
+
+function GetWifiDevInfo() {
+    wifiDevNum = 0;
+    for (var i=0; UserDevices.length > 0 && i < UserDevices.length-1; i++) {
+        if (UserDevices[i].PortType.toUpperCase() == "WIFI") {
+            wifiDev[wifiDevNum] = new USERDevice("","","","","","","","","","");
+            wifiDev[wifiDevNum] = UserDevices[i];
+            if (['SSID1', 'SSID3', 'SSID4', 'SSID5'].indexOf(UserDevices[i].Port) != -1) {
+                if (UserDevices[i].DevStatus.toUpperCase() == "ONLINE") {
+                    wifiDevOnline[wifiDevNumOnline] = new USERDevice("","","","","","","","","","");
+                    wifiDevOnline[wifiDevNumOnline] = UserDevices[i];
+                    wifiDevNumOnline++;
+                    wifiDevNum++;
+                } else {
+                    wifiDevOffline[wifiDevNumOffline] = new USERDevice("","","","","","","","","","");
+                    wifiDevOffline[wifiDevNumOffline] = UserDevices[i];
+                    wifiDevNumOffline++;
+                }
+            } else if (UserDevices[i].Port == "SSID2" || UserDevices[i].Port == "SSID6") {
+                if (UserDevices[i].DevStatus.toUpperCase() == "ONLINE") {
+                    guestwifiDevOnline[guestwifiDevNumOnline] = new USERDevice("","","","","","","","","","");
+                    guestwifiDevOnline[guestwifiDevNumOnline] = UserDevices[i];
+                    guestwifiDevNumOnline++;
+                    wifiDevNum++;
+                } else {
+                    guestwifiDevOffline[guestwifiDevNumOffline] = new USERDevice("","","","","","","","","","");
+                    guestwifiDevOffline[guestwifiDevNumOffline] = UserDevices[i];
+                    guestwifiDevNumOffline++;
+                }
+            }
+        }
+    }
+    document.getElementById("WIFInum").innerHTML = wifiDevNum;
+    
+    for (var j = 0;j < (wifiDevNumOnline + wifiDevNumOffline);j++) {
+        if (j == 3) {
+            var showDevice = wifiDevNumOnline + wifiDevNumOffline - 3;
+            ShowMoreDevice("wifiContent", showDevice);
+        }
+
+        if (j < wifiDevNumOnline) {
+            InitWifiDevOnline(wifiDevOnline[j], j, "");
+        } else {
+            var temp = j - wifiDevNumOnline;
+            InitWifiDevOffline(wifiDevOffline[temp],j, "");
+        }
+    }
+    for (var i = 0; i < guestwifiDevNumOnline; i++) {
+        InitWifiDevOnline(guestwifiDevOnline[i], i, "guest");
+    }
+
+    for (var i = 0; i < guestwifiDevNumOffline; i++) {
+        var temp = i + guestwifiDevNumOnline;
+        InitWifiDevOffline(guestwifiDevOffline[i], temp, "guest");
+    }
+    
+    var guestWifiNum = guestwifiDevNumOnline + guestwifiDevNumOffline;
+    document.getElementById("guesthideWifiNumSpan").innerHTML = guestWifiNum;
+    document.getElementById("guestShowwifiDeviceUl").title = framewifiinfo["framewifi005"] + guestWifiNum + framewifiinfo["framewifi006"];
+}
+
+var showStaBoostRelease = new Array;
+var showStaBoostReleaseId = new Array;
+var showStaBoostReleaseTime = new Array;
+function ShowWifiPic(ele) {
+    var id = ele.id.split("_")[1];
+    var isGuest = (ele.id.indexOf("guest") != -1) ? "guest" : "";
+    if ($('#' + isGuest + 'wifiLi_' + id + ' .icon2').hasClass('rotate')) {
+        $('#' + isGuest + 'wifiLi_' + id + ' .icon2').removeClass("rotate");
+        $('#' + isGuest + 'wifiLi_' + id + ' .icon2').addClass("rotate1");
+    } else {
+        $('#' + isGuest + 'wifiLi_' + id + ' .icon2').removeClass("rotate1");
+        $('#' + isGuest + 'wifiLi_' + id + ' .icon2').addClass("rotate");
+    }
+    var mac = document.getElementById(isGuest + 'OnlineMac'+ id).innerHTML;
+    $('#' + isGuest + 'clickShow_' + id).slideToggle().siblings('#clickShow_' + id + ' .submenu').slideUp(); 
+    if (CheckMacInBoost(mac)) {
+        $('#' + isGuest + 'wifiBoost_'+ id).slideToggle().siblings('#clickShow_' + id + ' .submenu').slideDown();
+        $('#' + isGuest + 'Delboostimg_' + id).slideToggle().siblings('#clickShow_' + id + ' .submenu').slideUp(); 
+        $('#' + isGuest + 'boostimg_'+ id).slideToggle().siblings('#clickShow_' + id + ' .submenu').slideDown();
+        var staBoostInfo = GetBoostInfoByMac(mac);
+        if (staBoostInfo.Duration != 0) {
+            clearInterval(showStaBoostRelease[id]);
+            setDisplay(isGuest + 'boostTime_'+ id, 1);
+            showStaBoostReleaseId[id] = isGuest + 'boostTime_'+ id;
+            showStaBoostReleaseTime[id] = staBoostInfo.StaOnlineStu;
+            showStaBoostRelease[id] = setInterval(function(){ 
+                document.getElementById(showStaBoostReleaseId[id]).innerHTML = TimeChange(showStaBoostReleaseTime[id]);
+                if (showStaBoostReleaseTime[id] == 0) {
+                    clearInterval(showStaBoostRelease[id]);
+                    return;
+                }
+                showStaBoostReleaseTime[id] = showStaBoostReleaseTime[id] - 1;
+            }, 1000)
+        } else {
+            setDisplay(isGuest + 'boostTime_'+ id, 0);
+        }
+    } else {
+        setDisplay(isGuest + 'boostTime_'+ id, 0);
+    }
+}
+
+function TimeFormatChange(time) {
+    if (time < 10) {
+        return "0" + time;
+    }
+
+    return time;
+}
+
+function TimeChange(time) {
+    var hour = parseInt(time / 3600);
+    var min = parseInt((time%3600) / 60);
+    var second = parseInt((time%3600)%60);
+    
+    return TimeFormatChange(hour) + ":" + TimeFormatChange(min) + ":" + TimeFormatChange(second);
+}
+
+function InitAlertContent() {
+    var html = "";
+    window.parent.document.getElementById("wifiContent").innerHTML = "";
+    html += '<p class="title">' +
+            '<span class="language-string">' + framewifiinfo["framewifi010"] + '</span>' +
+            '</p>' + 
+            '<div class="row">' + 
+            '<div class="wifileft" style="float:left;padding-left: 15px;">' +
+            '<input id="boost2" class="radio-checked" name="allow" value="2" type="radio">' +
+            '<label for="boost2" style="margin-right:5px"></label>' +
+            '<span class="language-string">2 ' + framewifiinfo["framewifi011"] + '</span>' +
+            '</div>' +
+            '<div class="wifileft" style="float:left;padding-left: 15px;">' +
+            '<input id="boost4" class="radio-checked" name="allow" value="4" type="radio">' +
+            '<label for="boost4" style="margin-right:5px"></label>' +
+            '<span class="language-string">4 ' + framewifiinfo["framewifi011"] + '</span>' +
+            '</div>' +
+            '<div class="wifileft" style="float:left;padding-left: 15px;">' +
+            '<input id="boost8" class="radio-checked" name="allow" value="8" type="radio">' +
+            '<label for="boost8" style="margin-right:5px"></label>' +
+            '<span class="language-string">8 ' + framewifiinfo["framewifi011"] + '</span>' +
+            '</div>' +
+            '<div class="wifileft" style="float:left;padding-left: 15px;">' +
+            '<input id="boost0" class="radio-checked" name="allow" checked="checked" value="0" type="radio">' +
+            '<label for="boost0" style="margin-right:5px"></label>' +
+            '<span class="language-string">' + framewifiinfo["framewifi012"] + '</span>' +
+            '</div></div>' +
+            '<div class="apply-cancel">' +
+            '<input id="continueButton" class="button button-apply add" type="button" value="' + framewifiinfo["framewifi013"] + '" onClick="SaveBoostTime();">' +
+            '<input id="cancelButton" class="button button-cancel " type="button" value="' + framewifiinfo["framewifi014"] + '" onClick="hideWifiBlock();">' +
+            '</div>';
+    window.parent.document.getElementById("wifiContent").innerHTML = html;
+}
+
+function showWifiBoost(val) {
+    boostAddId = val;
+    window.parent.getElementById("wifiBackground").style.display = "";
+    window.parent.getElementById("wifiContent").style.display = "";
+    InitAlertContent();
+}
+
+function GetBoostInfoByMac(mac) {
+    for (var i=0; i < wlanStaBoostList.length - 1; i++) {
+        if (wlanStaBoostList[i].MACAddress == mac.toUpperCase()) {
+            return wlanStaBoostList[i];
+        }
+    }
+}
+
+function CheckMacInBoost(mac) {
+    for (var i=0; i < wlanStaBoostList.length - 1; i++) {
+        if (wlanStaBoostList[i].MACAddress == mac.toUpperCase()) {
+            return true;
+        }
+    }
+    return false;
+}
+
+function GetAssociateInfoByMac(macAddr) {
+    for (var key in associatedDevice) {
+        if (associatedDevice[key] == null) {
+            continue;
+        }
+        if (associatedDevice[key].AssociatedDeviceMACAddress.toUpperCase() == macAddr.toUpperCase()) {
+            return associatedDevice[key];
+        }
+    }
+
+    return 0;
+}
+
+function GetFreqByMac(macAddr) {
+    for (var key in associatedDevice) {
+        if (associatedDevice[key] == null) {
+            continue;
+        }
+        if (associatedDevice[key].AssociatedDeviceMACAddress.toUpperCase() == macAddr.toUpperCase()) {
+            var instID = getWlanInstFromDomain(associatedDevice[key].domain);
+            if (instID >= ssidStart2G && instID <= ssidEnd2G) {
+                return "2G";
+            } else if (instID >= ssidStart5G && instID <= ssidEnd5G) {
+                return "5G";
+            }
+        }
+    }
+}
+
+function SaveBoostTime() {
+    window.parent.hideWifiBlock();
+    var index = boostAddId.split("_")[1];
+    var staInfo = (boostAddId.indexOf("guest") != -1) ? guestwifiDevOnline : wifiDevOnline;
+    var boostTime = window.parent.getRadioValue("allow");
+    var macAddr = staInfo[index].MacAddr.toUpperCase();
+    var freq = GetFreqByMac(macAddr);
+    if (checkAddStaBoost(freq) == false) {
+        return;
+    }
+
+    var Form = new webSubmitForm();
+    Form.addParameter('x.MACAddress', macAddr);
+    Form.addParameter('x.Duration', boostTime);
+    Form.addParameter('x.X_HW_Token', getValue('onttoken'));
+
+    var addDomain = 'InternetGatewayDevice.LANDevice.1.WiFi.Radio.1.X_HW_WLANSTABoost';
+    if (freq == "5G") {
+        addDomain = 'InternetGatewayDevice.LANDevice.1.WiFi.Radio.2.X_HW_WLANSTABoost';
+    }
+
+    Form.setAction('add.cgi?x='+ addDomain +'&RequestFile=overview.asp');
+    Form.submit();
+}
+
+function DelWifiBoost(val) {
+    var index = val.split("_")[1];
+    var staInfo = (val.indexOf("guest") != -1) ? guestwifiDevOnline : wifiDevOnline;
+    var macAddr = staInfo[index].MacAddr.toUpperCase();
+    var DelStaBoostDomain = wlanStaBoostMap[macAddr].domain;
+    var Form = new webSubmitForm();
+    Form.addParameter(DelStaBoostDomain, '');
+    Form.addParameter('x.X_HW_Token', getValue('onttoken'));
+    Form.setAction('del.cgi?x='+ 'InternetGatewayDevice.LANDevice.1.WiFi.Radio.{i}.X_HW_WLANSTABoost' +'&RequestFile=overview.asp');
+    Form.submit();
+}
+
+function hideAllWifiDetailInfo(isGuest) {
+    if (isGuest === 'guest') {
+        for (let i = 0; i < guestwifiDevNumOnline; i++) {
+            $("#" + isGuest + "wifidetailInfo_" + i).hide();
+        }
+
+        return;
+    }
+
+    for (let i = 0; i < wifiDevNumOnline; i++) {
+        $("#" + isGuest + "wifidetailInfo_" + i).hide();
+    }
+}
+
+function showWifiDetailInfo(val) {
+    var index = val.split("_")[1];
+    var isGuest = (val.indexOf("guest") != -1) ? "guest" : "";
+    $("#" + isGuest + "wifidetailInfo_" + index).css({"position":"absolute","left":"-45px"});
+    if ($("#" + isGuest + "wifidetailInfo_" + index).is(':hidden')) {
+            hideAllWifiDetailInfo(isGuest);
+            $("#" + isGuest + "wifidetailInfo_" + index).show();
+    } else {
+            $("#" + isGuest + "wifidetailInfo_" + index).hide();
+    }
+}
+
+function hideAllEthDetailInfo() {
+    for (let i = 0; i < ethNumOnline; i++) {
+        $("#detailInfo_" + i).hide();
+    }
+
+    for (let j = 0; j < newLastList.length; j++) {
+        $('#moreDetailInfo_' + j).hide();
+    }
+}
+
+function showEthDetailInfo(val, isMoreDev) {
+    var index = val.split("-")[1];
+    var prefix = isMoreDev ? "#moreDetailInfo_" : "#detailInfo_";
+    $(prefix + index).css({"position":"absolute","left":"-45px"});
+    if ($(prefix + index).is(':hidden')) {
+            hideAllEthDetailInfo();
+            $(prefix + index).show();
+    } else {
+            $(prefix + index).hide();
+    }
+}
+
+function showEditbox(id) {
+    $("#box").fadeIn();
+    for (let i = 0; i < allUserDevinfo.length; i++) {
+        if (allUserDevinfo[i].Domain == id.split("-")[0]) {
+            if (allUserDevinfo[i].UserDevAlias == "") {
+                $("#devNameSet").val(allUserDevinfo[i].HostName)
+                $("#devNameSet").attr("value",allUserDevinfo[i].HostName);
+            } else {
+                $("#devNameSet").val(allUserDevinfo[i].UserDevAlias)
+                $("#devNameSet").attr("value",allUserDevinfo[i].UserDevAlias);
+
+            }
+        }
+    }
+    var docheight = $(document).height();
+    $("body").append("<div id='greybackground'></div>");
+    $("#greybackground").css({"opacity":"0.5","height":docheight,"position":"absolute","left":"0","top":"0","background":"#000","width":"100%","height":"100%","z-index":"5"});
+    editNetWorkDomain = id.split("-")[0];
+    editNetWorkNum = id.split("-")[1]
+    $("#img_" + editNetWorkNum).attr("src", activeImgInfo[editNetWorkNum]);
+　　 return false;
+}
+</script>
+<script language="JavaScript" type="text/javascript">
+var vagIndex = 0;
+var vagLastInst = '0';
+var upMode = '1';
+var opticInfo = '\x2d18\x2e07';
+var ethLinkStatus = new Array(new ethLinkMode("InternetGatewayDevice.X_HW_DEBUG.AMP.LANPort.1.CommonConfig","1"),new ethLinkMode("InternetGatewayDevice.X_HW_DEBUG.AMP.LANPort.2.CommonConfig","0"),new ethLinkMode("InternetGatewayDevice.X_HW_DEBUG.AMP.LANPort.3.CommonConfig","0"),new ethLinkMode("InternetGatewayDevice.X_HW_DEBUG.AMP.LANPort.4.CommonConfig","0"),null);
+
+function ethLinkMode(domain, Link) {
+    this.domain	= domain;
+    this.Link = Link;
+}
+
+function stProfile(Domain, Enable)
+{
+    this.Domain = Domain;
+    this.Enable = Enable;
+}
+
+var AllProfile = new Array(new stProfile("InternetGatewayDevice.Services.VoiceService.1.VoiceProfile.1","Enabled"),null);
+vagIndex = GetVagIndexByInst(vagLastInst);
+
+function GetVagIndexByInst(vagInst)
+{
+    for (var i = 0; i < AllProfile.length-1; i++) {
+        if (AllProfile[i].profileid == vagInst) {
+            return i;
+        }
+    }
+
+    return 0;
+}
+
+function stRingSchedule(Domain, Enable, Policy)
+{
+    this.Domain = Domain;
+    this.Enable = Enable;
+    this.Policy = Policy;
+}
+
+var scheduleStatus = new Array(new stRingSchedule("InternetGatewayDevice.Services.VoiceService.1.VoiceProfile.1.X_HW_RingSchedule","0","0"),null);
+
+function stLine(Domain, DirectoryNumber, PhyReferenceList, X_HW_Description)
+{
+    this.Domain = Domain;
+    this.DirectoryNumber = DirectoryNumber;
+    this.PhyReferenceList = PhyReferenceList;
+    this.X_HW_Description = X_HW_Description;
+}
+
+function stLineURI(Domain, URI)
+{
+    this.Domain = Domain;
+    this.URI = URI;
+}
+
+var AllLineURI = new Array(new stLineURI("InternetGatewayDevice.Services.VoiceService.1.VoiceProfile.1.Line.1.SIP","\x2b15555550100"),new stLineURI("InternetGatewayDevice.Services.VoiceService.1.VoiceProfile.1.Line.2.SIP","line2"),null);
+var LineURI = new Array();
+for (var i = 0; i < AllLineURI.length-1; i++) {
+    LineURI[i] = AllLineURI[i];
+}
+
+var AllLine = new Array(new stLine("InternetGatewayDevice.Services.VoiceService.1.VoiceProfile.1.Line.1","\x2b15555550100","1",""),new stLine("InternetGatewayDevice.Services.VoiceService.1.VoiceProfile.1.Line.2","line2","2",""),null);
+var LineList = new Array(new Array(),new Array(),new Array(),new Array());
+
+for (var i = 0; i < AllLine.length-1; i++) {
+    var temp = AllLine[i].Domain.split('.');
+     var Vagindex = GetVagIndexByInst(temp[5]);
+    LineList[Vagindex].push(AllLine[i]);
+}
+
+function stAuth(Domain, AuthUserName)
+{
+    this.Domain = Domain;
+    this.AuthUserName = AuthUserName;
+
+    var temp = Domain.split('.');
+    this.key = '.' + temp[7] + '.';
+}
+
+var AllAuth = new Array(new stAuth("InternetGatewayDevice.Services.VoiceService.1.VoiceProfile.1.Line.1.SIP","\x2b15555550100\x40ims\x2evodafone\x2ept"),new stAuth("InternetGatewayDevice.Services.VoiceService.1.VoiceProfile.1.Line.2.SIP","line2"),null);
+var Auth = new Array();
+for (var i = 0; i < AllAuth.length-1; i++) {
+    Auth[i] = AllAuth[i];
+}
+
+    var User = new Array();
+function stUser(Domain, UserId)
+{
+    this.Domain = Domain;
+    this.UserId = UserId;
+}
+
+for (var i = 0; i < AllLine.length - 1; i++) {
+    User[i] = new stUser();
+    User[i].UserId = AllLine[i].DirectoryNumber;
+}
+
+var vdfPhoneNumber = new Array();
+function  GetPhoneNumber(inputstring)
+{
+    if (inputstring.indexOf(":") >= 0) {
+        var URIpart = inputstring.split(':');
+        var k1 = URIpart[1];
+        var k2 = k1.split('@');
+        var k3 = k2[0];
+        if (k3 == "") {
+            number = "--";
+        } else {
+            number = k3;
+        }
+    } else {
+        var URIpart = inputstring.split('@');
+        var k = URIpart[0];
+        if (k == "") {
+            number = "--";
+        } else {
+            number = k;
+        }
+    }
+    return number;
+}
+
+for (i = 0; i < AllLine.length - 1; i++) {
+    if (AllLineURI[i].URI != "") {
+        vdfPhoneNumber[i] = GetPhoneNumber(LineURI[i].URI);
+    } else if (AllLine[i].DirectoryNumber != "") {
+        vdfPhoneNumber[i] = GetPhoneNumber(User[i].UserId);
+    } else if (AllAuth[i].AuthUserName != "") {
+        vdfPhoneNumber[i] = GetPhoneNumber(Auth[i].AuthUserName);
+    } else {
+        vdfPhoneNumber[i] = "--";
+    }
+}
+
+var htmlDescriptionId = new Array();
+for (i = 0; i < AllLine.length - 1; i++) {
+    htmlDescriptionId[i] = "Description" + i;
+}
+
+function setVagInfo()
+{
+    if (AllProfile[0] == null) {
+        return;
+    }
+    for (i = 0; i < AllLine.length - 1; i++) {
+         setText(htmlDescriptionId[i], AllLine[i].X_HW_Description);
+    }
+}
+
+function AddSubmitParam(Form,type)
+{
+    var domain = "";
+    var add = "";
+    var des = "";
+    if (AllProfile[0] == null) {
+        return false;
+    }
+
+    domain ='x=' + AllProfile[vagIndex].Domain;
+    for (i = 0; i < AllLine.length - 1; i++) {
+        add = 'Add' + i;
+        var des = add +'.X_HW_Description';
+        Form.addParameter(des, getValue(htmlDescriptionId[i]));
+        domain += '&' + add +'=' + LineList[vagIndex][i].Domain;
+    }
+    Form.addParameter('x.X_HW_Token', getValue('onttoken'));
+
+    Form.setAction('set.cgi?' + domain + '&RequestFile=html/voip/vdfphonenumber/sipphonenumvdf.asp');
+    setDisable('SaveApply_button',1);   
+    setDisable('Cancel_button',1);      
+}
+
+function vdfvspaisValidStrlen(cfgName, val, len)
+{
+    if (val.length > len) {
+        AlertEx(cfgName + vdfsipline['vspa_cantexceed']  + len  + vdfsipline['vspa_characters']);
+        return false;
+    }
+}
+
+function CheckForm(type)
+{
+    var ulret=0;
+    var i = AllLine.length - 1;
+    for (i = 0; i < AllLine.length - 1; i++) {
+        ulret |= CheckForm1(i); 
+    }
+    if (ulret != true) {
+        return false;
+    }
+
+    return true;
+}
+
+function CheckForm1(index)
+{
+    if ('' != removeSpaceTrim(getValue(htmlDescriptionId[index]))) {
+        if (vdfvspaisValidStrlen(vdfsipline['vspa_linedes'],getValue(htmlDescriptionId[index]),32) == false) {
+            return false;
+        }
+    }
+    return true;
+}
+
+function ButtonCancel()
+{
+    LoadFrame();
+}
+
+
+function LoadFrame()
+{
+    setVagInfo();
+    if (AllLine.length - 1 >= 1) {
+        setDisplay('PhoneNumApplyCancel', 1);
+    }
+}
+var htmlInfo = "";
+for (let i = 0; i < imgInfo.length; i++) {
+    htmlInfo += '<div class="icon">'
+        htmlInfo += '<img src="'+ imgInfo[i] + '" id="img_'+ i + '" onclick="changeImage(this.id)">'
+    htmlInfo += '</div>'
+}
+function changeImage(id) {
+    selectImgIndex = id.split("_")[1];
+    $("#img_" + editNetWorkNum).attr("src", imgInfo[editNetWorkNum]);
+    $("#img_" + selectImgIndex).attr("src", activeImgInfo[selectImgIndex]);
+    editNetWorkNum = selectImgIndex
+}
+function SaveApply() {
+    var Form = new webSubmitForm();
+    Form.addParameter('x.UserDevAlias',document.getElementById('devNameSet').value);
+    Form.addParameter('x.GroupName',GroupNameFirst+";"+editNetWorkNum);
+    Form.addParameter('x.X_HW_Token', getValue('onttoken'));
+    Form.setAction('set.cgi?' + 'x=' + editNetWorkDomain + '&RequestFile=overview.asp');                                
+    Form.submit();	
+}
+function RedirectiveToUSB() {
+    window.parent.onFirstMenuChange("SettingsID", "ContentSharingID");
+    window.parent.onThirdMenuChange("SambaID");
+}
+
+function ShowNoConnection()
+{
+    document.getElementById("accessstatetxt").innerHTML = framedesinfo["frame045"];
+    document.getElementById("accessstate").style.background = "red";
+    document.getElementById("accessstateline").style.zIndex = -1;
+    document.getElementById("accessstateimg").src = "../images/red_line_long.png";
+}
+
+function SetAccessStatus(opticState)
+{
+    if (upMode == 3 || upMode == 11) {
+        if (ethLinkStatus[ethLinkStatus.length - 2].Link == 1) {
+            document.getElementById("accessstatetxt").innerHTML = framedesinfo["frame044"];
+        } else {
+            ShowNoConnection();
+        }
+    } else {
+        if (opticState == false) {
+            ShowNoConnection();
+        }
+    }
+}
+
+function LoadOpticFrame()
+{
+    var isOpticalOk = true;
+
+    if(opticInfo == "--" || opticInfo == "") {
+        isOpticalOk = false;
+    }
+    SetAccessStatus(isOpticalOk);
+    setOntImage();
+}
+
+function setOntImage() {
+    let image = 'ont-l3-wide-pt.png';
+    if (productName === 'HN8255X6S-8X') {
+        image = 'HN8255X6s-8X.jpg';
+        $(".ontleft").css("width", '36%');
+    }
+    image = '../images/' + image;
+    $("#ontImg").attr("src", image);
+}
+</script>
+<style>
+.wifihide{
+    
+}
+.strengthIcon {
+    width: 18px;
+    height: auto;
+    float: left;
+    display: block;
+    margin-top: 15px;
+    margin-left: 4px;
+}
+</style>
+
+
+</head>
+<body class="mainpagebody" onload="LoadOpticFrame();" style="position: relative;">
+<div id="mainpage">
+    <div id="ontimgpart">
+       <div class="ontleft">
+            <div id="accessstate" class="overview-image-top-left" style="right:142px;">
+                <span id="accessstatetxt"><script>document.write(framedesinfo["frame043"]);</script></span>
+                <div id="accessstateline" class="line" style="z-index:-1;right:-150px;">
+                    <img id="accessstateimg" src="../images/green_line_long.png" />
+                </div>
+            </div>
+       </div>
+       <div class="ontright">
+            <img id="ontImg" />
+       </div>
+    </div>
+    <div id="onlineconnectpart">
+        <div id="onlineTop"></div>
+        <div id="onlineBottom">
+            <ul class="onlineBottomul">
+                <script>
+                    let usbOnline = [];
+                    var printerCount = 0;
+                    for (var i = 0; i < usblist.length - 1; i++) {
+                        if (usblist[i].Status.toUpperCase() == "ONLINE") {
+                            usbOnline.push(usblist[i]);
+                        }
+                    }
+                    if (dftPrinter.PrinterName != "") {
+                        printerCount = 1;
+                    }
+                    var usbDevCount = usbOnline.length + printerCount;
+                    document.write('<li style="width:20%;box-sizing: border-box;padding-left: 41px;cursor: pointer;font-family:VodafoneRgRegular;" id="WIFInum" onclick="RedirectToWifiGeneral()">0</li>');
+                    document.write('<li style="width:30%;font-family:VodafoneRgRegular;text-align: center;">' + onLineDev.length + '</li>');
+                    document.write('<li style="width:30%;text-align: center;font-family:VodafoneRgRegular;">' + usbOnline.length + '</li>');
+                    document.write('<li class="voipAlline" Onclick="RedirectToPhone();" style="width:20%;padding-right: 41px;text-align: right;cursor: pointer;font-family:VodafoneRgRegular;">' + htmlencode(AllLine.length - 1) + '</li>');
+                </script>
+               
+            </ul>
+        </div>
+    </div>
+    <div id="contentpart">
+        <div class="coulmn1">
+            <div id="itemTitle">
+                <a href="#" onClick="RedirectToWifiGeneral()">
+                    <img src="../images/wifi.png" class="icon">
+                    <span>Wi-Fi</span>
+                </a>
+            </div>
+            <ul class="container">
+                <li class="li1" onClick="RedirectToWifiSche()">
+                    <a href="#">
+                        <img src="../images/schedule.png" class="icon">
+                        <span>
+                            <script>
+                                var wlanScheEnable = '0';
+                                if (wlanScheEnable == 1) {
+                                    document.write(framewifiinfo["framewifi001"]);
+                                } else {
+                                    document.write(framewifiinfo["framewifi008"]);
+                                }
+                            </script>
+                        </span>
+                    </a>
+                </li>
+                <li class="li1" onClick="RedirectToWifiWps()">
+                    <a href="#">
+                        <img src="../images/wps.png" class="icon">
+                        <span>
+                            <script>
+                                var wlanWpsEnable2g = '0';
+                                var wlanWpsEnable5g = '0';
+                                if (wlanWpsEnable2g == 1 || wlanWpsEnable5g == 1) {
+                                    document.write(framewifiinfo["framewifi004"]);
+                                } else {
+                                    document.write(framewifiinfo["framewifi009"]);
+                                }
+                            </script>
+                        </span>
+                    </a>
+                </li>
+            </ul>
+            <ul class="container" id="wifiContent">
+            </ul>
+        </div>
+        <div class="coulmn1">
+            <div id="itemTitle">
+                <a onClick='RedirectToNetwork();'>
+                    <img src="../images/network.png" class="icon">
+                    <script>
+                        document.write('<span>'+ framedesinfo["frame041"] + '</span>');
+                    </script>
+                </a>
+            </div>
+            <ul class="container" id="network">
+            </ul>
+            
+        </div>
+        <div class="coulmn1">
+            <div id="itemTitle">
+                <a onClick="RedirectToUSB();">
+                    <img style="width: 23px;" src="../images/usb.png" class="icon">
+                    <span>USB</span>
+                </a>
+            </div>
+            <ul class="container" id="usb">
+                <script>
+                var sharingEnable = "";
+                if (SMBEnable == 1) {
+                    sharingEnable = framedesinfo['frame031'];
+                } else {
+                    sharingEnable = framedesinfo['frame032'];
+                }
+                var printerName = (dftPrinter.PrinterName != "") ? dftPrinter.PrinterName : "--";
+                    document.write('<li class="li1">');
+                    document.write('<a href="#">');
+                    document.write('<img src="../images/schedule.png" class="icon">');
+                    document.write('<span onClick="RedirectiveToUSB()">'+ framedesinfo['frame030'] + sharingEnable + '</span>');
+                    document.write('</a></li>');
+                if (dftPrinter.PrinterEnable == 1) {
+                    document.write('<li class="li2" onclick = "intoPrint()">');
+                    document.write('<img src="../images/printer.png" class="icon">');
+                    document.write('<span>'+ printerName + '</span>');
+                    document.write('</li>');
+                }
+                    var usbHtml = "";
+                    for (var i = 0; i < usblist.length - 1; i++) {
+                        if (usblist[i].Status.toUpperCase() == "ONLINE") {
+                            usbHtml += '<li class="li2">';
+                        } else {
+                            usbHtml += '<li class="li2 op40">';
+                        }
+                        usbHtml += '<img src="../images/hard-drive.png" class="icon">';
+                        usbHtml += '<span>'+ htmlencode(usblist[i].Name) + '</span>';
+                        usbHtml += '</li>';
+                    }
+                    $("#usb").append(usbHtml);
+                </script>
+            </ul>
+        </div>
+        <div class="coulmn1">
+            <div id="itemTitle">
+                <a onClick='RedirectToPhone();'>
+                    <img style="width: 20px;" src="../images/phone.png" class="icon">
+                    <script>
+                        document.write('<span>'+ framephoneinfo["framephone001"] + '</span>');
+                    </script>
+                </a>
+            </div>
+            <ul class="container">
+                <li class="li1">
+                    <a href="#">
+                        <img src="../images/schedule.png" class="icon">
+                        <script language="JavaScript" type="text/javascript">
+                            if (scheduleStatus[0].Enable == 1) {
+                                document.write('<span onClick="RedirectToPhoneSche()">' + framephoneinfo["framephone002"] + '</span>');
+                            } else {
+                                document.write('<span onClick="RedirectToPhoneSche()">' + framephoneinfo["framephone003"] + '</span>');
+                            }
+                        </script>
+                    </a>
+                </li>
+                    <script language="JavaScript" type="text/javascript">
+                        if (AllLine.length - 1 == 0) {
+                            document.write('<li class="li2"><span> </span></li>');
+                        }
+                        for (i = 0; i < AllLine.length - 1; i++) {
+                            document.write('<li class="li2"><img src="../images/landline-phone.png" class="icon">')
+                            document.write('<span onClick="RedirectToVoiceState();">' + htmlencode(vdfPhoneNumber[i]) + '</span></li>');
+                        }
+                    </script>
+                
+            </ul>
+        </div>
+        <div style="clear:both;padding-top:10px;">
+            <div class="coulmn1">
+                <div id="itemTitle">
+                    <a href="#" onClick="RedirectToWifiGeneral()">
+                        <img src="../images/wifi.png" class="icon">
+                        <span> Guest Wi-Fi</span>
+                    </a>
+                </div>
+                <ul id="guestShowwifiDeviceUl" class="container" onClick="ShowwifiDevice(this.id);">
+                    <li class="li2" style="padding:0 0 0 15px;overflow: hidden;text-overflow: ellipsis;white-space: nowrap;padding-right:20px;">
+                        <span style="display: inline;margin-left:-3px;" id="guestshowDeviceSpan"><script>document.write(framewifiinfo["framewifi005"]);</script></span>
+                        <span style="display: inline;" id="guesthideWifiNumSpan"></span>
+                        <span style="display: inline;" id="guestshowDeviceSpanLast"><script>document.write(framewifiinfo["framewifi006"]);</script></span>
+                        <span style="display:none;" id="guesthideDeviceSpan"><script>document.write(framewifiinfo["framewifi007"]);</script></span>
+                        <i><img src="../images/arrow-down.png" class="icon2"></i>
+                    </li>
+                </ul>
+                <ul class="container wifihide" id="guestwifiContent">
+                </ul>
+            </div>
+        </div>
+    </div>
+
+        <div id="box">
+            <script>
+                document.write('<p class="title">' + framedesinfo["frame036"] + '</p>');
+            </script>
+            <div class="icon-row">
+                <script>
+                    document.write('<p class="language-string">' + framedesinfo["frame037"] + '</p>');
+                </script>
+                <div class="icon-wrapper" id = "editIcon">
+                    <div class="icon">
+                        <img src="../images/game.png">
+                    </div>
+                </div>
+            </div>
+            <div class="name-row">
+                <script>
+                    document.write('<p class="language-string">' + framedesinfo["frame034"] + '</p>');
+                </script>
+                <input type="text" value="" class="name-input" id= "devNameSet">
+            </div>
+            <div class="apply-cancel">
+                <script>
+                    document.write('<input class="button button-apply" value="' + framedesinfo["frame038"] + '" title="Save" type="button" onClick="SaveApply()">');
+                    document.write('<input class="button button-cancel" value="' + framedesinfo["frame039"] + '" title="Cancel" type="button" id="closeBtn">');
+                </script>
+            </div>
+        </div>
+    <script>
+    $(function(){
+　　var screenwidth;
+    var screenheight;
+    var mytop;
+    var getPosLeft;
+    var getPosTop
+　　screenwidth = $(window).width();
+　　screenheight = $(window).height();
+　　mytop = $(document).scrollTop();
+　　getPosLeft = screenwidth/2 - 260;
+　　getPosTop = screenheight/2 - 150;
+　　//$("#box").css({"left":getPosLeft,"top":getPosTop});
+　　$(window).resize(function(){
+　　  screenwidth = $(window).width();
+　　  screenheight = $(window).height();
+　　  mytop = $(document).scrollTop();
+　　  getPosLeft = screenwidth/2 - 260;
+　　  getPosTop = screenheight/2 - 150;
+　　  //$("#box").css({"left":getPosLeft,"top":getPosTop+mytop});
+　　});
+ 
+　　$(window).scroll(function(){
+　　  screenwidth = $(window).width();
+　　  screenheight = $(window).height();
+　　  mytop = $(document).scrollTop();
+　　  getPosLeft = screenwidth/2 - 260;
+　　  getPosTop = screenheight/2 - 150;
+　　});
+ 
+　　$("#closeBtn").click(function() {
+　　  $("#box").hide();
+      $("#img_" + editNetWorkNum).attr("src", imgInfo[editNetWorkNum]);
+　　  $("#greybackground").remove();
+　　  return false;
+　　});
+});
+$("#editIcon").html(htmlInfo)
+$("#img_" + editNetWorkNum).attr("src", activeImgInfo[editNetWorkNum]);
+for (let i = 0; i < allUserDevinfo.length; i++) {
+        if (allUserDevinfo[i].Domain == editNetWorkDomain) {
+            if (allUserDevinfo[i].HostName == "") {
+                $("#devNameSet").val(allUserDevinfo[i].UserDevAlias)
+                $("#devNameSet").attr("value",allUserDevinfo[i].UserDevAlias);
+            } else {
+                $("#devNameSet").val(allUserDevinfo[i].HostName)
+                $("#devNameSet").attr("value",allUserDevinfo[i].HostName);
+            }
+        }
+    }
+if (curUserType == 2) {
+    $('a').css('pointer-events', 'none');
+    $('li').css('pointer-events', 'none');
+}
+    </script>
+</div>
+<input type="hidden" name="onttoken" id="hwonttoken" value="0404040404040404040404040404040404040404040404040404040404040404">
+<div style="height:10px;width:100%;"></div>
+</body>
+</html>

--- a/tests/fixtures/huawei/sipphonenumvdf.asp
+++ b/tests/fixtures/huawei/sipphonenumvdf.asp
@@ -1,0 +1,404 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<meta http-equiv="Pragma" content="no-cache" />
+<script language="JavaScript" src="../../../resource/common/util.js?03fa5651e1972f63229090335"></script>
+<script language="JavaScript" src="../../../resource/common/InitForm.asp?03fa5651e1972f63229090335"></script>
+<script language="JavaScript" src="../../../resource/lancutdes.js?03fa5651e1972f632290903352138485273"></script>
+<script language="JavaScript" src='../../../Cusjs/InitFormCus.js?03fa5651e1972f63229090335'></script>
+<script language="JavaScript" src="../../../resource/common/jquery.min.js?03fa5651e1972f63229090335"></script>
+<link rel="stylesheet"  href='../../../resource/common/style.css?03fa5651e1972f63229090335' type='text/css'>
+<link rel="stylesheet" href='../../../Cuscss/frame.css?03fa5651e1972f63229090335' type='text/css'>
+<title>Phone Numbers</title>
+<style type="text/css">
+table.table-three-columns th {
+  font-weight: normal;
+  height: 30px;
+  line-height: 30px;
+  padding: 10px;
+  text-align: left;
+}
+h1 {
+    color: #e60000;
+    font-family: "VodafoneRgRegular";
+    font-size: 45px;
+    font-weight: 350;
+    line-height: 50px;
+    margin-bottom: 10px;
+}
+
+h2 {
+    font-size: 16px;
+    font-weight: normal;
+    margin-bottom: 30px;
+    line-height: 24px;
+}
+h3 {
+    color: #e60000;
+    font-family: "VodafoneLtRegular";
+    font-size: 28px;
+    line-height: 50px;
+    padding-left: 40px;
+}
+.h3-content th {
+  border-bottom: 1px solid #e6e6e6;
+}
+.h3-content td, .h3-content th {
+  font-weight: normal;
+  height: 30px;
+  line-height: 30px;
+  padding: 10px;
+  text-align: left;
+  /*width: 33.3%;*/
+}
+.h3-content table.table-three-columns th {
+  width: auto;
+}
+input.button {
+  border-radius: 3px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.6);
+  font-size: 16px;
+  font-weight: bold;
+  padding: 0 20px;
+  height: 34px;
+  line-height: 34px;
+  background-color: #ffffff;
+}
+input.button.button-apply {
+  background-color: #b141ad;
+  color: #fff;
+}
+.apply-cancel input:last-of-type {
+  margin-right: 0;
+}
+.wordclass
+{
+	word-wrap: break-word;
+	word-break: break-all;
+	max-width: 270px;
+}
+</style>
+
+<script language="JavaScript" type="text/javascript">
+var vagIndex = 0;
+var vagLastInst = '0';
+
+function stProfile(Domain, Enable)
+{
+    this.Domain = Domain;
+    this.Enable = Enable;
+
+}
+
+var AllProfile = new Array(new stProfile("InternetGatewayDevice.Services.VoiceService.1.VoiceProfile.1","Enabled"),null);
+vagIndex = GetVagIndexByInst(vagLastInst);
+
+function GetVagIndexByInst(vagInst)
+{
+    for(var i = 0; i < AllProfile.length-1; i++)
+    {
+        if(AllProfile[i].profileid == vagInst)
+        {
+            return i;
+        }
+    }
+    return 0;
+}
+
+function stLine(Domain, DirectoryNumber, PhyReferenceList, X_HW_Description)
+{
+    this.Domain = Domain;
+    this.DirectoryNumber = DirectoryNumber;
+    this.PhyReferenceList = PhyReferenceList;
+    this.X_HW_Description = X_HW_Description;
+}
+
+function stLineURI(Domain, URI)
+{
+	this.Domain = Domain;
+    this.URI = URI;
+}
+var AllLineURI = new Array(new stLineURI("InternetGatewayDevice.Services.VoiceService.1.VoiceProfile.1.Line.1.SIP","\x2b15555550100"),new stLineURI("InternetGatewayDevice.Services.VoiceService.1.VoiceProfile.1.Line.2.SIP","line2"),null);
+var LineURI = new Array();
+for (var i = 0; i < AllLineURI.length-1; i++) 
+    LineURI[i] = AllLineURI[i];
+	
+var AllLine = new Array(new stLine("InternetGatewayDevice.Services.VoiceService.1.VoiceProfile.1.Line.1","\x2b15555550100","1",""),new stLine("InternetGatewayDevice.Services.VoiceService.1.VoiceProfile.1.Line.2","line2","2",""),null);
+var LineList = new Array(new Array(),new Array(),new Array(),new Array());
+
+for (var i = 0; i < AllLine.length-1; i++)
+{
+    var temp = AllLine[i].Domain.split('.');
+    var Vagindex = GetVagIndexByInst(temp[5]);
+    LineList[Vagindex].push(AllLine[i]);
+}
+
+function stAuth(Domain, AuthUserName)
+{
+    this.Domain = Domain;
+    this.AuthUserName = AuthUserName;
+    
+    var temp = Domain.split('.');
+    this.key = '.' + temp[7] + '.';
+}
+
+var AllAuth = new Array(new stAuth("InternetGatewayDevice.Services.VoiceService.1.VoiceProfile.1.Line.1.SIP","\x2b15555550100\x40ims\x2evodafone\x2ept"),new stAuth("InternetGatewayDevice.Services.VoiceService.1.VoiceProfile.1.Line.2.SIP","line2"),null);
+var Auth = new Array();
+for (var i = 0; i < AllAuth.length-1; i++) 
+    Auth[i] = AllAuth[i];
+
+var User = new Array();
+
+function stUser(Domain, UserId)
+{
+    this.Domain = Domain;
+    this.UserId = UserId;
+}
+
+for (var i = 0; i < AllLine.length - 1; i++)
+{
+    User[i] = new stUser();
+    User[i].UserId = AllLine[i].DirectoryNumber;
+}
+
+var vdfPhoneNumber = new Array();
+function  GetPhoneNumber(inputstring)
+{
+	if( inputstring.indexOf(":") >= 0)       
+	{
+		var URIpart = inputstring.split(':');
+		var k1 = URIpart[1];
+		var k2 = k1.split('@');
+		var k3 = k2[0];
+		if (k3 == "")
+		{   
+			number = "--";
+		}
+		else
+		{    
+			number = k3;
+		}
+	 }
+	 else
+	 {
+		 var URIpart = inputstring.split('@');
+		 var k = URIpart[0];
+		if (k == "")
+		{    
+			number = "--";
+		}
+		else
+		{   
+			number = k; 
+		}
+	 }
+	 return number;
+}
+
+for (i = 0; i < AllLine.length - 1; i++)
+{
+	if(AllLineURI[i].URI != "")
+	{
+		vdfPhoneNumber[i] = GetPhoneNumber(LineURI[i].URI);	
+	}
+	else if(AllLine[i].DirectoryNumber != "")
+	{
+		vdfPhoneNumber[i] = GetPhoneNumber(User[i].UserId);
+	}
+	else if(AllAuth[i].AuthUserName != "")
+	{
+		vdfPhoneNumber[i] = GetPhoneNumber(Auth[i].AuthUserName);
+	}
+	else
+	{
+		vdfPhoneNumber[i] = "--";
+	}
+}
+
+var htmlDescriptionId = new Array();
+for (i = 0; i < AllLine.length - 1; i++)
+{
+    htmlDescriptionId[i] = "Description" + i;	
+}
+
+function setVagInfo()
+{
+    if(AllProfile[0] == null)
+    {
+        return;
+    }
+	for (i = 0; i < AllLine.length - 1; i++)
+	{
+		setText(htmlDescriptionId[i], AllLine[i].X_HW_Description);
+	}
+}
+
+function AddSubmitParam(Form,type)
+{    
+    var domain = "";
+	var add = "";
+	var des = "";
+    if(AllProfile[0] == null)
+    {
+        return false;
+    }
+
+	domain ='x=' + AllProfile[vagIndex].Domain;
+	for(i = 0; i < AllLine.length - 1; i++)
+	{
+		add = 'Add' + i;
+		var des = add +'.X_HW_Description';
+		Form.addParameter(des, getValue(htmlDescriptionId[i]));
+		domain += '&' + add +'=' + LineList[vagIndex][i].Domain;
+	}
+	Form.addParameter('x.X_HW_Token', getValue('onttoken'));	
+
+    Form.setAction('set.cgi?' + domain + '&RequestFile=html/voip/vdfphonenumber/sipphonenumvdf.asp');
+    setDisable('SaveApply_button',1);   
+    setDisable('Cancel_button',1);      
+}
+
+function vdfvspaisValidStrlen(cfgName, val, len)           
+{
+    if (val.length > len)
+    {
+        AlertEx(cfgName + vdfsipline['vspa_cantexceed']  + len  + vdfsipline['vspa_characters']);
+        return false;
+    }        
+}
+
+function CheckForm(type)
+{
+    var ulret=0;  	
+	var i = AllLine.length - 1;
+	for(i = 0; i < AllLine.length - 1; i++) 
+	{
+		ulret |= CheckForm1(i); 
+	}
+    if (ulret != true )
+    {
+        return false;
+    }
+    
+    return true;
+}
+
+function CheckForm1(index)
+{ 
+    if ( '' != removeSpaceTrim(getValue(htmlDescriptionId[index])))
+    {
+        if (vdfvspaisValidStrlen(vdfsipline['vspa_linedes'],getValue(htmlDescriptionId[index]),32) == false)
+        {
+            return false;
+        }    
+    }
+    return true;
+}
+
+function ButtonCancel()
+{
+	LoadFrame();
+}
+
+function LoadFrame()
+{
+    setVagInfo();
+	if(AllLine.length - 1 >= 1)    
+	{
+		setDisplay('PhoneNumApplyCancel', 1);
+	}
+}
+
+</script>
+</head>
+<body class="mainbody" onload="LoadFrame();">
+<div id="content" class="content-phone-numbers">
+<h1>
+  <span class="language-string" name="PAGE_PHONE_NUMBERS_TITLE"></span>
+	<script language="JavaScript" type="text/javascript">
+	  document.write(vdfsipline['vspa_vdfphonenums']);
+	</script>
+ </h1>
+<h2>
+  <span class="language-string" name="PAGE_PHONE_NUMBERS_SUBTITLE">
+  	<script language="JavaScript" type="text/javascript">
+	  document.write(vdfsipline['vspa_vdfphonenumdes']);
+	</script>
+  </span></h2>
+<h3>
+  <span class="language-string" name="PAGE_PHONE_NUMBERS_TABLE_1_TITLE">
+    <script language="JavaScript" type="text/javascript">
+	  document.write(vdfsipline['vspa_vdfyouphone']);
+	</script>
+   </span></h3>
+    <div class="phoneNumbersContent">
+      <div class="h3-content">
+	  <form id="PhoneSetConfigForm1">
+    <table class="table-three-columns">
+      <thead>
+      <tr>
+        <th><span class="language-string" name="PAGE_PHONE_NUMBERS_TABLE_2_COLTITLE_1">
+		  <script language="JavaScript" type="text/javascript">
+			document.write(vdfsipline['vspa_vdfconnect']);
+		  </script>
+		</span></th>
+        <th><span class="language-string" name="PAGE_PHONE_NUMBERS_TABLE_1_COLTITLE">
+		  <script language="JavaScript" type="text/javascript">
+			document.write(vdfsipline['vspa_vdfphonenum']);
+		  </script>
+        </span></th>
+        <th><span class="language-string" name="PAGE_PHONE_NUMBERS_TABLE_1_COLTITLE_2">
+		  <script language="JavaScript" type="text/javascript">
+			document.write(vdfsipline['vspa_vdfname']);
+		  </script>
+		</span></th>
+      </tr>
+      </thead>
+      <tbody>
+	    <script language="JavaScript" type="text/javascript">
+		if(AllLine.length - 1 == 0)  
+		{
+			document.write('<tr>');
+			document.write('<td> --</td>');			 
+			document.write('<td> --</td>');	
+			document.write('<td>');
+			document.write('<input  type="text" class="no-specials" maxlength="32" value=" "/>');
+			document.write('</td>');
+			document.write('</tr>');
+		}
+		for(i = 0; i < AllLine.length - 1; i++)
+		{
+			document.write('<tr>');
+			document.write('<td>' + vdfsipline['vspa_vdfTel'] + ' ' + htmlencode(AllLine[i].PhyReferenceList) + '</td>');							
+			document.write('<td class="wordclass" >' + htmlencode(vdfPhoneNumber[i]) + '</td>');	
+			document.write('<td>');
+			document.write('<input id=' +htmlDescriptionId[i] + ' type="text" class="no-specials" maxlength="32" />');
+			document.write('</td>');
+			document.write('</tr>');
+		}
+		</script> 
+      </tbody>
+  </table>
+</form>
+</div>
+
+<table>
+<div id="PhoneNumApplyCancel" class="clearfix apply-cancel" style="display:none">
+        <input type="hidden" name="onttoken" id="hwonttoken" value="0606060606060606060606060606060606060606060606060606060606060606">
+        <input name="SaveApply_button" id="SaveApply_button" type="button" class="button button-apply" value="Apply" onClick="Submit();"/> 
+          <script type="text/javascript">
+          document.getElementsByName('SaveApply_button')[0].value = vdfsipline['vspa_vdfapply'];  
+          </script>
+        <input name="Cancel_button" id="Cancel_button" type="button" class="button button-cancel" value="Cancel" onClick="ButtonCancel();"/> 
+          <script type="text/javascript">
+              document.getElementsByName('Cancel_button')[0].value = vdfsipline['vspa_vdfcancel'];  
+          </script> 
+</div>
+</table>
+<table width="100%" border="0" cellspacing="0" cellpadding="0">
+    <tr><td class="height10p"></td></tr>
+</table>
+
+</body>
+</html>

--- a/tests/test_huawei.py
+++ b/tests/test_huawei.py
@@ -283,7 +283,7 @@ def test_get_devices_data(base_url: URL, monkeypatch: pytest.MonkeyPatch) -> Non
 
 
 def test_get_sensor_data(base_url: URL, monkeypatch: pytest.MonkeyPatch) -> None:
-    """Parse sensor fields from index + WAN fixtures."""
+    """Parse sensor fields from index, WAN, and status fixtures."""
     api = _api(base_url)
     api._session_cookie = "Cookie=sid=test"  # noqa: SLF001
     api._product_name = "HG8247B7-8N"  # noqa: SLF001
@@ -293,6 +293,8 @@ def test_get_sensor_data(base_url: URL, monkeypatch: pytest.MonkeyPatch) -> None
             return _fixture("index.asp")
         if "getwanlist" in page:
             return _fixture("getwanlist.asp")
+        if "Status_ptvdf" in page:
+            return _fixture("Status_ptvdf.asp")
         if "sipphonenum" in page:
             return _fixture("sipphonenumvdf.asp")
         if "wanipv6" in page:
@@ -301,13 +303,20 @@ def test_get_sensor_data(base_url: URL, monkeypatch: pytest.MonkeyPatch) -> None
 
     monkeypatch.setattr(VodafoneStationHuaweiApi, "_request_text", _text)
     data = cast("dict[str, Any]", asyncio.run(_acall(api, "get_sensor_data")))
-    assert data["sys_firmware_version"] == "V5R024C00S114"
-    assert data["fw_version"] == "V5R024C00S114"
-    assert "day" in data["sys_uptime"] or ":" in data["sys_uptime"]
+    assert data["sys_model_name"]
+    assert data["sys_firmware_version"]
+    # Status page uptime is seconds; index falls back to day(s) HH:MM:SS.
+    assert data["sys_uptime"]
     assert data["wan_ip4_addr"] == "203.0.113.10"
     assert data["inter_ip_address"] == "203.0.113.10"
     assert data["fiber_ready"] == "1"
-    assert data["sys_serial_number"]
+    assert data["sys_serial_number"] == "TESTSERIAL00000001"
+    assert data["sys_hardware_version"] == "3F80.A"
+    assert data["sys_cpu_usage"] == "24%"
+    assert data["sys_memory_usage"] == "12%"
+    # Numeric HA sensors must not be present when the router has no value.
+    assert "down_str" not in data
+    assert "up_str" not in data
     assert data["phone_num1"] == "+15555550100"
 
 

--- a/tests/test_huawei.py
+++ b/tests/test_huawei.py
@@ -80,8 +80,13 @@ def test_convert_uptime_day_string(base_url: URL) -> None:
 def test_convert_uptime_seconds(base_url: URL) -> None:
     """Parse integer-second uptime."""
     api = _api(base_url)
+    before = datetime.now(tz=UTC)
     boot = api.convert_uptime("120")
-    assert datetime.now(tz=UTC) - boot >= timedelta(seconds=100)
+    after = datetime.now(tz=UTC)
+    expected_delta = timedelta(seconds=120)
+    assert before - expected_delta - timedelta(seconds=2) <= boot <= (
+        after - expected_delta + timedelta(seconds=2)
+    )
 
 
 def test_init_device_class_huawei(base_url: URL) -> None:
@@ -361,6 +366,7 @@ def test_set_wifi_status_posts_enable(
         seen["page"] = page
         seen["method"] = kwargs.get("method")
         seen["payload"] = kwargs.get("payload")
+        seen["params"] = kwargs.get("params")
         return "ok"
 
     monkeypatch.setattr(VodafoneStationHuaweiApi, "_request_text", _text)
@@ -379,8 +385,12 @@ def test_set_wifi_status_posts_enable(
             WifiBand.BAND_2_4_GHZ,
         )
     )
-    assert "WLANConfiguration.2" in str(seen["page"])
+    assert seen["page"] == "set.cgi"
     assert seen["method"] == HTTPMethod.POST
+    assert seen["params"] == {
+        "x": "InternetGatewayDevice.LANDevice.1.WLANConfiguration.2",
+        "RequestFile": "html/amp/ptvdf/vdfWlanBasicNew.asp",
+    }
     assert "x.Enable=1" in str(seen["payload"])
     assert "x.X_HW_Token=tok123" in str(seen["payload"])
 

--- a/tests/test_huawei.py
+++ b/tests/test_huawei.py
@@ -1,0 +1,383 @@
+# Copyright 2023 Simone Chemelli and contributors
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for Huawei (PT Vodafone) model API implementation."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+from http import HTTPMethod
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, cast
+
+import pytest
+
+from aiovodafone.const import WIFI_DATA, WifiBand, WifiType
+from aiovodafone.exceptions import CannotAuthenticate, GenericLoginError
+from aiovodafone.models.huawei import (
+    VodafoneStationHuaweiApi,
+    _decode_js_string,
+    _parse_ctor_calls,
+)
+from tests.conftest import FakeResponse, FakeSession
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Coroutine
+
+    from yarl import URL
+
+FIXTURES = Path(__file__).parent / "fixtures" / "huawei"
+
+
+def _fixture(name: str) -> str:
+    return (FIXTURES / name).read_text(encoding="utf-8", errors="replace")
+
+
+def _api(base_url: URL, session: FakeSession | None = None) -> VodafoneStationHuaweiApi:
+    return VodafoneStationHuaweiApi(
+        base_url,
+        "vodafone",
+        "secret",
+        cast("Any", session or FakeSession()),
+    )
+
+
+def _acall(
+    obj: object, method_name: str, *args: object, **kwargs: object
+) -> Coroutine[object, object, object]:
+    method = cast(
+        "Callable[..., Coroutine[object, object, object]]",
+        getattr(obj, method_name),
+    )
+    return method(*args, **kwargs)
+
+
+def test_decode_js_string() -> None:
+    """Decode Huawei \\xNN escapes."""
+    assert _decode_js_string(r"192\x2e168\x2e1\x2e1") == "192.168.1.1"
+    assert _decode_js_string("\ufefftoken") == "token"
+
+
+def test_parse_ctor_calls_user_device() -> None:
+    """Parse USERDevice constructors from GetLanUserDevInfo fixture."""
+    calls = _parse_ctor_calls(_fixture("GetLanUserDevInfo.asp"), "USERDevice")
+    assert len(calls) >= 6
+    assert calls[0][2].lower().count(":") == 5
+
+
+def test_convert_uptime_day_string(base_url: URL) -> None:
+    """Parse day(s) HH:MM:SS uptime format."""
+    api = _api(base_url)
+    before = datetime.now(tz=UTC)
+    boot = api.convert_uptime("1 day(s) 05:09:51")
+    after = datetime.now(tz=UTC)
+    expected_delta = timedelta(days=1, hours=5, minutes=9, seconds=51)
+    assert before - expected_delta - timedelta(seconds=2) <= boot <= after - expected_delta + timedelta(
+        seconds=2
+    )
+
+
+def test_convert_uptime_seconds(base_url: URL) -> None:
+    """Parse integer-second uptime."""
+    api = _api(base_url)
+    boot = api.convert_uptime("120")
+    assert datetime.now(tz=UTC) - boot >= timedelta(seconds=100)
+
+
+def test_init_device_class_huawei(base_url: URL) -> None:
+    """Ensure Huawei device type initializes Huawei API class."""
+    from aiovodafone.models import DeviceType, init_device_class
+
+    api = init_device_class(
+        base_url,
+        DeviceType.HUAWEI,
+        {"username": "u", "password": "p"},
+        cast("Any", FakeSession()),
+    )
+    assert isinstance(api, VodafoneStationHuaweiApi)
+
+
+def test_get_device_type_detects_huawei() -> None:
+    """Detect Huawei model from root login HTML markers."""
+    from aiovodafone.models import DeviceType, get_device_type
+
+    response = FakeResponse(
+        status=200,
+        text_data=_fixture("login_page.html"),
+        json_data={},
+        content_type="text/html",
+    )
+
+    def _get(*_args: object, **_kwargs: object) -> FakeResponse:
+        return response
+
+    session = FakeSession(get_impl=_get)
+    device_type, url = asyncio.run(get_device_type("192.168.1.1", cast("Any", session)))
+    assert device_type == DeviceType.HUAWEI
+    assert url.host == "192.168.1.1"
+
+
+def test_login_success_sets_session_cookie(
+    base_url: URL, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Successful login stores the raw Cookie=sid=... header value."""
+    api = _api(base_url)
+    calls: list[str] = []
+
+    class _Resp:
+        def __init__(self, status: int, text: str, headers: dict[str, str]) -> None:
+            self.status = status
+            self._text = text
+            self.headers = headers
+
+        async def text(self) -> str:
+            return self._text
+
+        async def read(self) -> bytes:
+            return self._text.encode()
+
+        def getall(self, key: str, default: list[str] | None = None) -> list[str]:
+            if key.lower() == "set-cookie" and "Set-Cookie" in self.headers:
+                return [self.headers["Set-Cookie"]]
+            return default or []
+
+    class _Headers(dict[str, str]):
+        def getall(self, key: str, default: list[str] | None = None) -> list[str]:
+            for k, v in self.items():
+                if k.lower() == key.lower():
+                    return [v]
+            return default or []
+
+    class _Session:
+        def __init__(self) -> None:
+            self.cookie_jar = type("J", (), {"clear": lambda self: None})()
+
+        async def request(self, method: str, url: object, **_kwargs: object) -> _Resp:
+            path = str(url)
+            calls.append(path)
+            if "GetRandCount" in path:
+                return _Resp(200, "abc123token", _Headers())
+            if "login.cgi" in path:
+                return _Resp(
+                    200,
+                    "Waiting...",
+                    _Headers(
+                        {
+                            "Set-Cookie": (
+                                "Cookie=sid=deadbeef:Language:portuguese:id=1;"
+                                "path=/;HttpOnly"
+                            )
+                        }
+                    ),
+                )
+            # Optional login-page probe for productName.
+            return _Resp(
+                200,
+                "var productName = 'HG8247B7\x2d8N';",
+                _Headers(),
+            )
+
+        async def __aenter__(self) -> _Session:
+            return self
+
+        async def __aexit__(self, *_args: object) -> None:
+            return None
+
+    class _Connector:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            return None
+
+        async def close(self) -> None:
+            return None
+
+    monkeypatch.setattr(
+        "aiovodafone.models.huawei.aiohttp.TCPConnector",
+        _Connector,
+    )
+    monkeypatch.setattr(
+        "aiovodafone.models.huawei.aiohttp.ClientSession",
+        lambda **_kwargs: _Session(),
+    )
+    monkeypatch.setattr(
+        "aiovodafone.models.huawei.aiohttp.DummyCookieJar",
+        lambda: object(),
+    )
+
+    # Skip onttoken refresh (would need authenticated GETs).
+    async def _no_token(self: VodafoneStationHuaweiApi) -> None:
+        return None
+
+    monkeypatch.setattr(VodafoneStationHuaweiApi, "_refresh_onttoken", _no_token)
+
+    assert asyncio.run(_acall(api, "login")) is True
+    assert api._session_cookie == "Cookie=sid=deadbeef:Language:portuguese:id=1"  # noqa: SLF001
+    assert any("GetRandCount" in c for c in calls)
+    assert any("login.cgi" in c for c in calls)
+
+
+def test_login_failure_raises(base_url: URL, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Missing sid cookie raises CannotAuthenticate."""
+
+    class _Resp:
+        status = 200
+        headers: dict[str, str] = {}
+
+        async def text(self) -> str:
+            return "fail"
+
+        async def read(self) -> bytes:
+            return b"fail"
+
+        def getall(self, *_args: object, **_kwargs: object) -> list[str]:
+            return []
+
+    class _Session:
+        async def request(self, *_args: object, **_kwargs: object) -> _Resp:
+            return _Resp()
+
+        async def __aenter__(self) -> _Session:
+            return self
+
+        async def __aexit__(self, *_args: object) -> None:
+            return None
+
+    class _Connector:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            return None
+
+        async def close(self) -> None:
+            return None
+
+    monkeypatch.setattr(
+        "aiovodafone.models.huawei.aiohttp.TCPConnector", _Connector
+    )
+    monkeypatch.setattr(
+        "aiovodafone.models.huawei.aiohttp.ClientSession",
+        lambda **_kwargs: _Session(),
+    )
+    monkeypatch.setattr(
+        "aiovodafone.models.huawei.aiohttp.DummyCookieJar", lambda: object()
+    )
+
+    api = _api(base_url)
+    with pytest.raises(CannotAuthenticate):
+        asyncio.run(_acall(api, "login"))
+
+
+def test_get_devices_data(base_url: URL, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Parse LAN devices from fixture."""
+    api = _api(base_url)
+    api._session_cookie = "Cookie=sid=test"  # noqa: SLF001
+
+    async def _text(self: VodafoneStationHuaweiApi, page: str, **_kwargs: object) -> str:
+        assert "GetLanUserDevInfo" in page
+        return _fixture("GetLanUserDevInfo.asp")
+
+    monkeypatch.setattr(VodafoneStationHuaweiApi, "_request_text", _text)
+    devices = asyncio.run(_acall(api, "get_devices_data"))
+    assert isinstance(devices, dict)
+    assert len(devices) >= 5
+    sample = next(iter(devices.values()))
+    assert sample.mac
+    assert sample.connection_type in {"WiFi", "Ethernet"}
+
+
+def test_get_sensor_data(base_url: URL, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Parse sensor fields from index + WAN fixtures."""
+    api = _api(base_url)
+    api._session_cookie = "Cookie=sid=test"  # noqa: SLF001
+    api._product_name = "HG8247B7-8N"  # noqa: SLF001
+
+    async def _text(self: VodafoneStationHuaweiApi, page: str, **_kwargs: object) -> str:
+        if page == "index.asp":
+            return _fixture("index.asp")
+        if "getwanlist" in page:
+            return _fixture("getwanlist.asp")
+        if "sipphonenum" in page:
+            return _fixture("sipphonenumvdf.asp")
+        if "wanipv6" in page:
+            return _fixture("html_bbsp_common_wanipv6state.asp")
+        raise AssertionError(page)
+
+    monkeypatch.setattr(VodafoneStationHuaweiApi, "_request_text", _text)
+    data = cast("dict[str, Any]", asyncio.run(_acall(api, "get_sensor_data")))
+    assert data["sys_firmware_version"] == "V5R024C00S114"
+    assert data["fw_version"] == "V5R024C00S114"
+    assert "day" in data["sys_uptime"] or ":" in data["sys_uptime"]
+    assert data["wan_ip4_addr"] == "203.0.113.10"
+    assert data["inter_ip_address"] == "203.0.113.10"
+    assert data["fiber_ready"] == "1"
+    assert data["sys_serial_number"]
+    assert data["phone_num1"] == "+15555550100"
+
+
+def test_get_wifi_data(base_url: URL, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Parse Wi-Fi SSIDs and passwords from fixtures."""
+    api = _api(base_url)
+    api._session_cookie = "Cookie=sid=test"  # noqa: SLF001
+
+    async def _text(self: VodafoneStationHuaweiApi, page: str, **_kwargs: object) -> str:
+        if page == "overview.asp":
+            return _fixture("overview.asp")
+        if "getWlanPsw" in page:
+            return _fixture("getWlanPsw.asp")
+        raise AssertionError(page)
+
+    monkeypatch.setattr(VodafoneStationHuaweiApi, "_request_text", _text)
+    data = cast("dict[str, Any]", asyncio.run(_acall(api, "get_wifi_data")))
+    wifi = data[WIFI_DATA]
+    assert wifi["main"]["on"] == 1
+    assert wifi["main"]["ssid"] == "TestSSID"
+    assert wifi["main"]["password"]
+    assert wifi["guest"]["on"] == 0
+    assert "qr_code" in wifi["guest"]
+    assert wifi["main_5g"]["on"] == 1
+    assert wifi["guest_5g"]["ssid"].endswith("Guest")
+
+
+def test_set_wifi_status_posts_enable(
+    base_url: URL, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """set_wifi_status posts Enable to the correct WLANConfiguration instance."""
+    api = _api(base_url)
+    api._session_cookie = "Cookie=sid=test"  # noqa: SLF001
+    api.csrf_token = "tok123"
+    seen: dict[str, object] = {}
+
+    async def _text(
+        self: VodafoneStationHuaweiApi,
+        page: str,
+        **kwargs: object,
+    ) -> str:
+        seen["page"] = page
+        seen["method"] = kwargs.get("method")
+        seen["payload"] = kwargs.get("payload")
+        return "ok"
+
+    monkeypatch.setattr(VodafoneStationHuaweiApi, "_request_text", _text)
+
+    async def _refresh(self: VodafoneStationHuaweiApi) -> None:
+        self.csrf_token = "tok456"
+
+    monkeypatch.setattr(VodafoneStationHuaweiApi, "_refresh_onttoken", _refresh)
+
+    asyncio.run(
+        _acall(
+            api,
+            "set_wifi_status",
+            True,
+            WifiType.GUEST,
+            WifiBand.BAND_2_4_GHZ,
+        )
+    )
+    assert "WLANConfiguration.2" in str(seen["page"])
+    assert seen["method"] == HTTPMethod.POST
+    assert "x.Enable=1" in str(seen["payload"])
+    assert "x.X_HW_Token=tok123" in str(seen["payload"])
+
+
+def test_request_text_requires_auth(base_url: URL) -> None:
+    """Unauthenticated requests raise GenericLoginError."""
+    api = _api(base_url)
+    with pytest.raises(GenericLoginError):
+        asyncio.run(_acall(api, "_request_text", "index.asp"))


### PR DESCRIPTION
## Summary

Adds support for Huawei-based Vodafone Station / ONT devices (e.g. PT Vodafone `HG8247B7-8N`).

These routers use a different web UI than the existing Sercomm / Technicolor / Homeware / UltraHub backends:

- Login via `/asp/GetRandCount.asp` + `/login.cgi` (token is TCP-connection-bound)
- Session cookie named literally `Cookie` (`Cookie=sid=...`)
- Device/WAN/Wi-Fi data scraped from ASP/JS endpoints

### Changes

- New `DeviceType.HUAWEI` + `VodafoneStationHuaweiApi`
- Detection from root login page markers (`login.cgi` + `GetRandCount.asp`)
- Implemented: login/logout, connected devices, sensors, Wi-Fi status/credentials, guest QR, Wi-Fi enable/disable, best-effort reboot
- Unit tests + anonymized fixtures

### Tested

- Live against HG8247B7-8N (PTVDF firmware)
- `pytest` green (including new `tests/test_huawei.py`)

## Notes

- ONT serial is often not exposed on the user UI; a stable fallback id is used (`model-wan_ip`)
- Reboot is best-effort on this firmware family

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Huawei routers and ONT devices.
  * Added Huawei login, authentication, and session handling.
  * Added access to device, sensor, Wi‑Fi, WAN, IPv6, voice, and DOCSIS information.
  * Added Wi‑Fi status updates and router restart controls.
* **Bug Fixes**
  * Improved handling of Huawei-specific response formats and authentication errors.
* **Tests**
  * Added comprehensive coverage for Huawei device detection, login, data retrieval, and controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->